### PR TITLE
Handle games with unusual DS Protect implementations

### DIFF
--- a/arm9/source/Arm9Patcher.cpp
+++ b/arm9/source/Arm9Patcher.cpp
@@ -14,6 +14,7 @@
 #include "patches/arm9/PokemonDownloaderArm9Patch.h"
 #include "patches/arm9/OverlayPatches/FsStartOverlayHookPatch.h"
 #include "patches/arm9/OverlayPatches/DSProtectPatches/DSProtectOverlayPatch.h"
+#include "patches/arm9/OverlayPatches/DSProtectPatches/DSProtectPuyoPuyo7Patch.h"
 #include "patches/arm9/OverlayPatches/PokemonIr/PokemonIrApPatch.h"
 #include "patches/arm9/OverlayPatches/GoldenSunDarkDawn/GoldenSunDarkDawnOverlayHookPatch.h"
 #include "SecureSysCallsUnusedSpaceLocator.h"
@@ -276,6 +277,42 @@ void Arm9Patcher::AddGameSpecificPatches(
 {
     switch (gameCode)
     {
+        // Dragon Ball: Origins 2
+        case GAMECODE("BDBE"):
+        {
+            // BDBE;2;1.23;111111;0x1FC;-1;0x0
+            // BDBE;3;1.23;111111;0x47DC;-1;0x0
+            overlayHookPatch->AddOverlayPatch(new DSProtectOverlayPatch(2, 0x1FC, DSProtectVersion::v1_23, ~0u));
+            overlayHookPatch->AddOverlayPatch(new DSProtectOverlayPatch(3, 0x47DC, DSProtectVersion::v1_23, ~0u));
+            break;
+        }
+        case GAMECODE("BDBJ"):
+        {
+            // BDBJ;2;1.23;111111;0x1FC;-1;0x0
+            // BDBJ;3;1.23;111111;0x4C34;-1;0x0
+            overlayHookPatch->AddOverlayPatch(new DSProtectOverlayPatch(2, 0x1FC, DSProtectVersion::v1_23, ~0u));
+            overlayHookPatch->AddOverlayPatch(new DSProtectOverlayPatch(3, 0x4C34, DSProtectVersion::v1_23, ~0u));
+            break;
+        }
+        case GAMECODE("BDBP"):
+        {
+            // BDBP;2;1.23;111111;0x1FC;-1;0x0
+            // BDBP;3;1.23;111111;0x484C;-1;0x0
+            overlayHookPatch->AddOverlayPatch(new DSProtectOverlayPatch(2, 0x1FC, DSProtectVersion::v1_23, ~0u));
+            overlayHookPatch->AddOverlayPatch(new DSProtectOverlayPatch(3, 0x484C, DSProtectVersion::v1_23, ~0u));
+            break;
+        }
+        // Puyo Puyo 7
+        case GAMECODE("BYOJ"):
+        {
+            // BYOJ;9;1.08;100110;1.08;0x21AC;-1;0x0
+            // BYOJ;12;1.08;100101;1.08;0xC568;-1;0x0
+            // BYOJ;14;1.08;010101;1.08;0x13AB8;-1;0x0
+            // BYOJ;15;1.08;010110;1.08;0x16DF0;-1;0x0
+            // BYOJ;19;1.08;011010;1.08;0x17F8;-1;0x0
+            overlayHookPatch->AddOverlayPatch(new DSProtectPuyoPuyo7Patch());
+            break;
+        }
         // Pokemon HeartGold & SoulSilver
         case GAMECODE("IPGD"):
         case GAMECODE("IPGE"):

--- a/arm9/source/patches/arm9/OverlayPatches/DSProtectPatches/DSProtectPuyoPuyo7Patch.cpp
+++ b/arm9/source/patches/arm9/OverlayPatches/DSProtectPatches/DSProtectPuyoPuyo7Patch.cpp
@@ -1,0 +1,17 @@
+#include "common.h"
+#include "../../../PatchContext.h"
+#include "DSProtectPuyoPuyo7PatchAsm.h"
+#include "DSProtectPuyoPuyo7Patch.h"
+
+const void* DSProtectPuyoPuyo7Patch::InsertPatch(PatchContext& patchContext)
+{
+    // Next patch
+    puyopuyo7patch_nextAddress = next ? (const void*)next->InsertPatch(patchContext) : nullptr;
+
+    u32 patchSize = SECTION_SIZE(puyopuyo7patch);
+    void* patchAddress = patchContext.GetPatchHeap().Alloc(patchSize);
+    u32 entryAddress = (u32)&puyopuyo7patch_entry - (u32)SECTION_START(puyopuyo7patch) + (u32)patchAddress;
+    memcpy(patchAddress, SECTION_START(puyopuyo7patch), patchSize);
+
+    return (const void*)entryAddress;
+}

--- a/arm9/source/patches/arm9/OverlayPatches/DSProtectPatches/DSProtectPuyoPuyo7Patch.h
+++ b/arm9/source/patches/arm9/OverlayPatches/DSProtectPatches/DSProtectPuyoPuyo7Patch.h
@@ -1,0 +1,9 @@
+#pragma once
+#include "../OverlayPatch.h"
+
+/// @brief Arm9 overlay patch for DS Protect specifically for Puyo Puyo 7.
+class DSProtectPuyoPuyo7Patch : public OverlayPatch
+{
+public:
+    const void* InsertPatch(PatchContext& patchContext) override;
+};

--- a/arm9/source/patches/arm9/OverlayPatches/DSProtectPatches/DSProtectPuyoPuyo7PatchAsm.h
+++ b/arm9/source/patches/arm9/OverlayPatches/DSProtectPatches/DSProtectPuyoPuyo7PatchAsm.h
@@ -1,0 +1,8 @@
+#pragma once
+#include "sections.h"
+
+DEFINE_SECTION_SYMBOLS(puyopuyo7patch);
+
+extern "C" void puyopuyo7patch_entry();
+
+extern const void* puyopuyo7patch_nextAddress;

--- a/arm9/source/patches/arm9/OverlayPatches/DSProtectPatches/DSProtectPuyoPuyo7PatchAsm.s
+++ b/arm9/source/patches/arm9/OverlayPatches/DSProtectPatches/DSProtectPuyoPuyo7PatchAsm.s
@@ -1,0 +1,61 @@
+.cpu arm946e-s
+.syntax unified
+.section "puyopuyo7patch", "ax"
+.thumb
+
+// Puyo Puyo 7 includes DS Protect 1.08 *five times*:
+//
+// overlay id | function mask | overlay offset | A1 offset | NotA1 offset
+//     9      |    100110     |     0x21AC     |     -     |    0x2AD8
+//    12      |    100101     |     0xC568     |   0xCE94  |      -
+//    14      |    010101     |    0x13AB8     |  0x143E4  |      -
+//    15      |    010110     |    0x16DF0     |     -     |   0x1771C
+//    19      |    011010     |     0x17F8     |     -     |    0x2124
+//
+// Note that each overlay only contains either A1 or NotA1, and never both
+// This means we only need to patch one offset at each load
+
+.global puyopuyo7patch_entry
+.type puyopuyo7patch_entry, %function
+puyopuyo7patch_entry:
+    push {r5, lr}
+
+    ldm r5!, {r1, r2} // overlay_id, ram_start
+
+    cmp r1, #9
+    ldr r3, =0x2AD8
+    beq do_patch
+
+    cmp r1, #12
+    ldr r3, =0xCE94
+    beq do_patch
+
+    cmp r1, #14
+    ldr r3, =0x143E4
+    beq do_patch
+
+    cmp r1, #15
+    ldr r3, =0x1771C
+    beq do_patch
+
+    cmp r1, #19
+    bne continue_to_next
+    ldr r3, =0x2124
+
+do_patch:
+    ldr r1, =0xFFFFFCE0 // magic number to deactivate 1.08 function queue
+    str r1, [r2, r3]
+
+continue_to_next:
+    ldr r0, puyopuyo7patch_nextAddress
+    pop {r5, pc}
+
+.balign 4
+
+.global puyopuyo7patch_nextAddress
+puyopuyo7patch_nextAddress:
+    .word 0
+
+.pool
+
+.end


### PR DESCRIPTION
Adds special cases for games with unusual DS Protect implementations. As far as I know this is only two games:
- Dragon Ball: Origins 2 (USA, Europe, Japan), which includes version 1.23 twice in two different overlays. This gets the standard DS Protect overlay patch for each overlay.
- Puyo Puyo 7, which includes version 1.08 *five* times in five different overlays with different offsets for each one. This gets a custom patch to be more space efficient. This patch assembles to size 0x48