### PR TITLE
Move emunand to subdirectory `_pico`; Impl multi nand support; Added support for `DSi System Settings`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Pico Loader is a homebrew and retail DS(i) rom loader supporting a variety of pl
 ## Features
 - Supports both homebrew and retail DS(i) roms
 - Supports DSiWare and redirects NAND to the flashcard SD card (acting as "emunand", see below for how to setup)
+- Supports multi-region emunand (Standard, CHN and KOR)
 - Supports DS roms with an encrypted secure area if a DS arm7 bios is present at `/_pico/biosnds7.rom`
 - Supports a wide range of platforms, including popular flashcards and the DSpico
 - Built-in patches for DS Protect
@@ -56,25 +57,34 @@ The steps provided will assume you already have one of those environments set up
     - `savelist.bin` (generated in the `data` folder of the repo)
 
 ## Emunand
-When running DSiWare, Pico Loader redirects NAND to the flashcard SD card. This requires the following files and folders, obtained from a DSi nand dump, in the root of your flashcard SD card:
+When running DSiWare, Pico Loader redirects NAND to the flashcard SD card. This requires the following files and folders, obtained from a DSi nand dump or 3DS TWLNAND partition, in the `_pico` folder of your flashcard SD card (File names starting with **\*** indicate that they are optional and are used by a few system tools, such as `DSi System Settings`):
 - `photo` - The photo partition of nand will be redirected to this folder
-- `shared1`
-    - `TWLCFG0.dat`
-    - `TWLCFG1.dat`
-- `shared2`
-    - `launcher`
-        - `wrap.bin`
-- `sys`
-    - `log`
-        - `product.log`
-        - `shop.log`
-        - `sysmenu.log`
-    - `cert.sys`
-    - `dev.kp`
-    - `HWID.sgn`
-    - `HWINFO_N.dat`
-    - `HWINFO_S.dat`
-    - `TWLFontTable.dat`
+- `snd` - The sound files of nand will be redirected to this folder
+    - `0000` - The default sound file used by DSi Sound
+- `twln` - The standard region (aka worldwide) NAND folder
+    - `shared1`
+        - **\*** `TWLCFG0.dat`
+        - **\*** `TWLCFG1.dat`
+    - `shared2`
+        - `launcher`
+            - **\*** `wrap.bin`
+    - `sys`
+        - **\*** `cert.sys`
+        - **\*** `dev.kp`
+        - **\*** `HWID.sgn`
+        - **\*** `HWINFO_N.dat`
+        - **\*** `HWINFO_S.dat`
+        - `TWLFontTable.dat` - Normal Font (843.1KB)
+- `twlc` - The CHN region NAND folder (optional, only used by the CHN version of DSiWare)
+    - **•••**
+    - `sys`
+        - **•••**
+        - `TWLFontTable.dat` - CHN Font (568.1KB)
+- `twlk` - The KOR region NAND folder (optional, only used by the KOR version of DSiWare)
+    - **•••**
+    - `sys`
+        - **•••**
+        - `TWLFontTable.dat` - KOR Font (158.9KB)
 
 ## How to use Pico Loader from homebrew
 On the arm9:

--- a/arm7/source/loader/DsiWareSaveArranger.cpp
+++ b/arm7/source/loader/DsiWareSaveArranger.cpp
@@ -186,7 +186,7 @@ std::unique_ptr<DsiWareSaveArranger::fat_header_t> DsiWareSaveArranger::CreateFa
 bool DsiWareSaveArranger::CreateDeviceListPath(TCHAR* savePath, char* deviceListPath) const
 {
     auto fileInfo = std::make_unique<FILINFO>();
-    strcpy(deviceListPath, "nand:/");
+    strcpy(deviceListPath, "sdmc:/");
     char* shortPath = deviceListPath + 6;
     char* currentPathSegment = strchr(savePath, '/');
     do

--- a/arm7/source/loader/NdsLoader.cpp
+++ b/arm7/source/loader/NdsLoader.cpp
@@ -932,8 +932,8 @@ void NdsLoader::SetupDsiDeviceList()
     memset(deviceList, 0, sizeof(dsi_devicelist_t));
 
     char romRegion = (_romHeader.gameCode >> 24) & 0xFF;
-    const char *nandPath = "nand2:/_pico/twln";
-    const char *sharedPath = "nand2:/_pico/twln/shared1";
+    const char* nandPath = "nand2:/_pico/twln";
+    const char* sharedPath = "nand2:/_pico/twln/shared1";
     if (romRegion == 'C')
     {
         nandPath = "nand2:/_pico/twlc";

--- a/arm7/source/loader/NdsLoader.cpp
+++ b/arm7/source/loader/NdsLoader.cpp
@@ -932,14 +932,17 @@ void NdsLoader::SetupDsiDeviceList()
     memset(deviceList, 0, sizeof(dsi_devicelist_t));
 
     char romRegion = (_romHeader.gameCode >> 24) & 0xFF;
-    const char *nandPath = "nand2:/_twln";
+    const char *nandPath = "nand2:/_pico/twln";
+    const char *sharedPath = "nand2:/_pico/twln/shared1";
     if (romRegion == 'C')
     {
-        nandPath = "nand2:/_twlc";
+        nandPath = "nand2:/_pico/twlc";
+        sharedPath = "nand2:/_pico/twlc/shared1";
     }
     else if (romRegion == 'K')
     {
-        nandPath = "nand2:/_twlk";
+        nandPath = "nand2:/_pico/twlk";
+        sharedPath = "nand2:/_pico/twlk/shared1";
     }
 
     int listEntry = 0;
@@ -949,10 +952,10 @@ void NdsLoader::SetupDsiDeviceList()
     SetDeviceListEntry(deviceList->deviceList[listEntry++], 'B', "nand2", "/",
         DSI_DEVICELIST_ENTRY_FLAGS_DRIVE_SDMC | DSI_DEVICELIST_ENTRY_FLAGS_TYPE_PHYSICAL,
         DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_READ | DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_WRITE);
-    SetDeviceListEntry(deviceList->deviceList[listEntry++], 'D', "shared1", "nand:/shared1",
+    SetDeviceListEntry(deviceList->deviceList[listEntry++], 'D', "shared1", sharedPath,
         DSI_DEVICELIST_ENTRY_FLAGS_DRIVE_SDMC | DSI_DEVICELIST_ENTRY_FLAGS_TYPE_FOLDER,
         DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_READ | DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_WRITE);
-    SetDeviceListEntry(deviceList->deviceList[listEntry++], 'F', "photo", "nand:/photo",
+    SetDeviceListEntry(deviceList->deviceList[listEntry++], 'F', "photo", "nand2:/_pico/photo",
         DSI_DEVICELIST_ENTRY_FLAGS_DRIVE_SDMC | DSI_DEVICELIST_ENTRY_FLAGS_TYPE_FOLDER,
         DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_READ | DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_WRITE);
 

--- a/arm7/source/loader/NdsLoader.cpp
+++ b/arm7/source/loader/NdsLoader.cpp
@@ -931,8 +931,22 @@ void NdsLoader::SetupDsiDeviceList()
     auto deviceList = (dsi_devicelist_t*)_romHeader.arm7DeviceListAddress;
     memset(deviceList, 0, sizeof(dsi_devicelist_t));
 
+    char romRegion = (_romHeader.gameCode >> 24) & 0xFF;
+    const char *nandPath = "nand2:/_twln";
+    if (romRegion == 'C')
+    {
+        nandPath = "nand2:/_twlc";
+    }
+    else if (romRegion == 'K')
+    {
+        nandPath = "nand2:/_twlk";
+    }
+
     int listEntry = 0;
-    SetDeviceListEntry(deviceList->deviceList[listEntry++], 'A', "nand", "/",
+    SetDeviceListEntry(deviceList->deviceList[listEntry++], 'A', "nand", nandPath,
+        DSI_DEVICELIST_ENTRY_FLAGS_DRIVE_SDMC | DSI_DEVICELIST_ENTRY_FLAGS_TYPE_FOLDER,
+        DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_READ | DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_WRITE);
+    SetDeviceListEntry(deviceList->deviceList[listEntry++], 'B', "nand2", "/",
         DSI_DEVICELIST_ENTRY_FLAGS_DRIVE_SDMC | DSI_DEVICELIST_ENTRY_FLAGS_TYPE_PHYSICAL,
         DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_READ | DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_WRITE);
     SetDeviceListEntry(deviceList->deviceList[listEntry++], 'D', "shared1", "nand:/shared1",
@@ -956,7 +970,7 @@ void NdsLoader::SetupDsiDeviceList()
             DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_READ | DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_WRITE);
     }
 
-    SetDeviceListEntry(deviceList->deviceList[listEntry++], 'I', "sdmc", "nand:/.",
+    SetDeviceListEntry(deviceList->deviceList[listEntry++], 'I', "sdmc", "nand2:/.",
         DSI_DEVICELIST_ENTRY_FLAGS_DRIVE_SDMC | DSI_DEVICELIST_ENTRY_FLAGS_TYPE_FOLDER,
         DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_READ | DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_WRITE);
 

--- a/arm7/source/loader/NdsLoader.cpp
+++ b/arm7/source/loader/NdsLoader.cpp
@@ -30,6 +30,7 @@
 
 #define AP_LIST_PATH      "/_pico/aplist.bin"
 #define BIOS_NDS7_PATH    "/_pico/biosnds7.rom"
+#define BIOS_DSI7_PATH    "/_pico/biosdsi7.rom"
 
 typedef void (*entrypoint_t)(void);
 
@@ -290,7 +291,15 @@ void NdsLoader::Load(BootMode bootMode)
 
     if (Environment::IsDsiMode() && _romHeader.IsTwlRom())
     {
+        if (!TrySetupSSLCertKey())
+        {
+            LOG_WARNING("Failed to setup SSL cert key\n");
+        }
+
         SetupDsiDeviceList();
+
+        // restore MBK9 settings from rom header
+        REG_MBK9 = _romHeader.mbk9Setting[0] | (_romHeader.mbk9Setting[1] << 8) | (_romHeader.mbk9Setting[2] << 16);
 
         u32 scfgExt7 = 0x93FBFB00 | (_romHeader.arm7ScfgExt7 & 0x40407);
         REG_SCFG_EXT = scfgExt7;
@@ -978,6 +987,30 @@ void NdsLoader::SetupDsiDeviceList()
         DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_READ | DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_WRITE);
 
     strcpy(deviceList->appFileName, _dsiwareSaveResult.romFilePath);
+}
+
+bool NdsLoader::TrySetupSSLCertKey()
+{
+    if (!_romHeader.HasSSLCertAccess())
+    {
+        // No SSL cert access needed
+        return true;
+    }
+
+    auto bios7File = std::make_unique<FIL>();
+    auto keyTable = std::make_unique_for_overwrite<aes_u128_t>();
+    UINT bytesRead = 0;
+    if (f_open(bios7File.get(), BIOS_DSI7_PATH, FA_OPEN_EXISTING | FA_READ) != FR_OK ||
+        f_lseek(bios7File.get(), 0xB5D8 + 0x30) != FR_OK ||
+        f_read(bios7File.get(), keyTable.get(), sizeof(aes_u128_t), &bytesRead) != FR_OK ||
+        bytesRead != sizeof(aes_u128_t))
+    {
+        return false;
+    }
+
+    TwlAes().SetupKeySlot(0, (const aes_u128_t*)keyTable.get());
+
+    return true;
 }
 
 bool NdsLoader::TrySetupDsiWareSave()

--- a/arm7/source/loader/NdsLoader.cpp
+++ b/arm7/source/loader/NdsLoader.cpp
@@ -504,8 +504,11 @@ void NdsLoader::SetupSharedMemory(u32 cardId, u32 agbMem, u32 resetParam, u32 ro
     }
     else
     {
-        strcpy(TWL_SHARED_MEMORY->sysMenuVersionInfoContentId, "00000009");
-        TWL_SHARED_MEMORY->sysMenuVersionInfoContentLastInitialCode = 'P'; // europe
+        if (!TryFindDsiVerData())
+        {
+            strcpy(TWL_SHARED_MEMORY->sysMenuVersionInfoContentId, "00000009");
+            TWL_SHARED_MEMORY->sysMenuVersionInfoContentLastInitialCode = 'P'; // europe
+        }
 
         memcpy(TWL_SHARED_MEMORY->twlCardRomHeader, &_romHeader, sizeof(nds_header_twl_t));
         memcpy(TWL_SHARED_MEMORY->twlRomHeader, &_romHeader, sizeof(nds_header_twl_t));
@@ -1060,4 +1063,68 @@ bool NdsLoader::TryDecryptSecureArea()
 
     LOG_DEBUG("Decrypted secure area\n");
     return true;
+}
+
+bool NdsLoader::TryFindDsiVerData()
+{
+    if (!_romHeader.HasNandAccess())
+    {
+        return false;
+    }
+
+    char romRegion = (_romHeader.gameCode >> 24) & 0xFF;
+    const char* sysDataPath = "/_pico/twln/title/0003000f";
+    if (romRegion == 'C')
+    {
+        sysDataPath = "/_pico/twlc/title/0003000f";
+    }
+    else if (romRegion == 'K')
+    {
+        sysDataPath = "/_pico/twlk/title/0003000f";
+    }
+
+    FILINFO fno;
+    if (f_stat(sysDataPath, &fno) != FR_OK)
+    {
+        LOG_WARNING("DSi verdata not found\n");
+        return false;
+    }
+
+    char verDataRegion = 0;
+    auto verDataMetaFile = std::make_unique<FIL>();
+    static const char regionChars[] = { 'J', 'E', 'P', 'U', 'C', 'K' };
+    for (char region : regionChars)
+    {
+        char verDataMetaPath[64];
+        snprintf(verDataMetaPath, sizeof(verDataMetaPath), "%s/484e4c%02x/content/title.tmd", sysDataPath, region);
+        if (f_open(verDataMetaFile.get(), verDataMetaPath, FA_OPEN_EXISTING | FA_READ) == FR_OK)
+        {
+            verDataRegion = region;
+            break;
+        }
+    }
+
+    if (verDataRegion != 0)
+    {
+        u32 contentId = 0;
+        UINT bytesRead = 0;
+        if (f_lseek(verDataMetaFile.get(), 0x1E4) == FR_OK &&
+            f_read(verDataMetaFile.get(), &contentId, 4, &bytesRead) == FR_OK && bytesRead == 4)
+        {
+            char verDataContentId[9];
+            char verDataFilePath[64];
+            snprintf(verDataContentId, sizeof(verDataContentId), "%08x", static_cast<unsigned int>(__builtin_bswap32(contentId)));
+            snprintf(verDataFilePath, sizeof(verDataFilePath), "%s/484e4c%02x/content/%s.app",
+                     sysDataPath, verDataRegion, verDataContentId);
+            if (f_stat(verDataFilePath, &fno) == FR_OK)
+            {
+                strcpy(TWL_SHARED_MEMORY->sysMenuVersionInfoContentId, verDataContentId);
+                TWL_SHARED_MEMORY->sysMenuVersionInfoContentLastInitialCode = verDataRegion;
+                return true;
+            }
+        }
+    }
+
+    LOG_WARNING("DSi verdata not found\n");
+    return false;
 }

--- a/arm7/source/loader/NdsLoader.cpp
+++ b/arm7/source/loader/NdsLoader.cpp
@@ -1021,50 +1021,6 @@ bool NdsLoader::TrySetupDsiWareSave()
     return DsiWareSaveArranger().SetupDsiWareSave(_romPath, _romHeader, _dsiwareSaveResult);
 }
 
-bool NdsLoader::TryDecryptSecureArea()
-{
-    if (_romHeader.arm9RomOffset < 0x4000 || _romHeader.arm9RomOffset >= 0x8000)
-    {
-        return true;
-    }
-
-    if (((u32*)_romHeader.arm9LoadAddress)[0] == 0xE7FFDEFF &&
-        ((u32*)_romHeader.arm9LoadAddress)[1] == 0xE7FFDEFF)
-    {
-        return true;
-    }
-
-    u16 secureAreaCrc = swi_getCrc16(0xFFFF,
-        (const void*)_romHeader.arm9LoadAddress, 0x8000 - _romHeader.arm9RomOffset);
-    if (secureAreaCrc != _romHeader.secureAreaCrc)
-    {
-        return true;
-    }
-
-    auto bios7File = std::make_unique<FIL>();
-    auto keyTable = std::make_unique_for_overwrite<Blowfish::KeyTable>();
-    UINT bytesRead = 0;
-    if (f_open(bios7File.get(), BIOS_NDS7_PATH, FA_OPEN_EXISTING | FA_READ) != FR_OK ||
-        f_lseek(bios7File.get(), 0x30) != FR_OK ||
-        f_read(bios7File.get(), keyTable.get(), sizeof(Blowfish::KeyTable), &bytesRead) != FR_OK ||
-        bytesRead != sizeof(Blowfish::KeyTable))
-    {
-        return false;
-    }
-
-    auto blowfish = std::make_unique<Blowfish>(keyTable.get());
-    blowfish->TransformTable(_romHeader.gameCode, 3, 8);
-    blowfish->Decrypt(
-        (const void*)_romHeader.arm9LoadAddress,
-        (void*)_romHeader.arm9LoadAddress,
-        0x4800 - _romHeader.arm9RomOffset);
-    ((u32*)_romHeader.arm9LoadAddress)[0] = 0xE7FFDEFF;
-    ((u32*)_romHeader.arm9LoadAddress)[1] = 0xE7FFDEFF;
-
-    LOG_DEBUG("Decrypted secure area\n");
-    return true;
-}
-
 bool NdsLoader::TryFindDsiVerData()
 {
     if (!_romHeader.HasNandAccess())
@@ -1127,4 +1083,48 @@ bool NdsLoader::TryFindDsiVerData()
 
     LOG_WARNING("DSi verdata not found\n");
     return false;
+}
+
+bool NdsLoader::TryDecryptSecureArea()
+{
+    if (_romHeader.arm9RomOffset < 0x4000 || _romHeader.arm9RomOffset >= 0x8000)
+    {
+        return true;
+    }
+
+    if (((u32*)_romHeader.arm9LoadAddress)[0] == 0xE7FFDEFF &&
+        ((u32*)_romHeader.arm9LoadAddress)[1] == 0xE7FFDEFF)
+    {
+        return true;
+    }
+
+    u16 secureAreaCrc = swi_getCrc16(0xFFFF,
+        (const void*)_romHeader.arm9LoadAddress, 0x8000 - _romHeader.arm9RomOffset);
+    if (secureAreaCrc != _romHeader.secureAreaCrc)
+    {
+        return true;
+    }
+
+    auto bios7File = std::make_unique<FIL>();
+    auto keyTable = std::make_unique_for_overwrite<Blowfish::KeyTable>();
+    UINT bytesRead = 0;
+    if (f_open(bios7File.get(), BIOS_NDS7_PATH, FA_OPEN_EXISTING | FA_READ) != FR_OK ||
+        f_lseek(bios7File.get(), 0x30) != FR_OK ||
+        f_read(bios7File.get(), keyTable.get(), sizeof(Blowfish::KeyTable), &bytesRead) != FR_OK ||
+        bytesRead != sizeof(Blowfish::KeyTable))
+    {
+        return false;
+    }
+
+    auto blowfish = std::make_unique<Blowfish>(keyTable.get());
+    blowfish->TransformTable(_romHeader.gameCode, 3, 8);
+    blowfish->Decrypt(
+        (const void*)_romHeader.arm9LoadAddress,
+        (void*)_romHeader.arm9LoadAddress,
+        0x4800 - _romHeader.arm9RomOffset);
+    ((u32*)_romHeader.arm9LoadAddress)[0] = 0xE7FFDEFF;
+    ((u32*)_romHeader.arm9LoadAddress)[1] = 0xE7FFDEFF;
+
+    LOG_DEBUG("Decrypted secure area\n");
+    return true;
 }

--- a/arm7/source/loader/NdsLoader.cpp
+++ b/arm7/source/loader/NdsLoader.cpp
@@ -932,30 +932,30 @@ void NdsLoader::SetupDsiDeviceList()
     memset(deviceList, 0, sizeof(dsi_devicelist_t));
 
     char romRegion = (_romHeader.gameCode >> 24) & 0xFF;
-    const char* nandPath = "nand2:/_pico/twln";
-    const char* sharedPath = "nand2:/_pico/twln/shared1";
+    const char* nandPath = "sd:/_pico/twln";
+    const char* sharedPath = "sd:/_pico/twln/shared1";
     if (romRegion == 'C')
     {
-        nandPath = "nand2:/_pico/twlc";
-        sharedPath = "nand2:/_pico/twlc/shared1";
+        nandPath = "sd:/_pico/twlc";
+        sharedPath = "sd:/_pico/twlc/shared1";
     }
     else if (romRegion == 'K')
     {
-        nandPath = "nand2:/_pico/twlk";
-        sharedPath = "nand2:/_pico/twlk/shared1";
+        nandPath = "sd:/_pico/twlk";
+        sharedPath = "sd:/_pico/twlk/shared1";
     }
 
     int listEntry = 0;
     SetDeviceListEntry(deviceList->deviceList[listEntry++], 'A', "nand", nandPath,
         DSI_DEVICELIST_ENTRY_FLAGS_DRIVE_SDMC | DSI_DEVICELIST_ENTRY_FLAGS_TYPE_FOLDER,
         DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_READ | DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_WRITE);
-    SetDeviceListEntry(deviceList->deviceList[listEntry++], 'B', "nand2", "/",
+    SetDeviceListEntry(deviceList->deviceList[listEntry++], 'B', "sd", "/",
         DSI_DEVICELIST_ENTRY_FLAGS_DRIVE_SDMC | DSI_DEVICELIST_ENTRY_FLAGS_TYPE_PHYSICAL,
         DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_READ | DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_WRITE);
     SetDeviceListEntry(deviceList->deviceList[listEntry++], 'D', "shared1", sharedPath,
         DSI_DEVICELIST_ENTRY_FLAGS_DRIVE_SDMC | DSI_DEVICELIST_ENTRY_FLAGS_TYPE_FOLDER,
         DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_READ | DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_WRITE);
-    SetDeviceListEntry(deviceList->deviceList[listEntry++], 'F', "photo", "nand2:/_pico/photo",
+    SetDeviceListEntry(deviceList->deviceList[listEntry++], 'F', "photo", "sd:/_pico/photo",
         DSI_DEVICELIST_ENTRY_FLAGS_DRIVE_SDMC | DSI_DEVICELIST_ENTRY_FLAGS_TYPE_FOLDER,
         DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_READ | DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_WRITE);
 
@@ -973,7 +973,7 @@ void NdsLoader::SetupDsiDeviceList()
             DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_READ | DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_WRITE);
     }
 
-    SetDeviceListEntry(deviceList->deviceList[listEntry++], 'I', "sdmc", "nand2:/.",
+    SetDeviceListEntry(deviceList->deviceList[listEntry++], 'I', "sdmc", "sd:/.",
         DSI_DEVICELIST_ENTRY_FLAGS_DRIVE_SDMC | DSI_DEVICELIST_ENTRY_FLAGS_TYPE_FOLDER,
         DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_READ | DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_WRITE);
 

--- a/arm7/source/loader/NdsLoader.cpp
+++ b/arm7/source/loader/NdsLoader.cpp
@@ -27,6 +27,7 @@
 #include "DSMode.h"
 #include "Arm7IoRegisterClearer.h"
 #include "NdsLoader.h"
+#include "core/mini-printf.h"
 
 #define AP_LIST_PATH      "/_pico/aplist.bin"
 #define BIOS_NDS7_PATH    "/_pico/biosnds7.rom"

--- a/arm7/source/loader/NdsLoader.h
+++ b/arm7/source/loader/NdsLoader.h
@@ -72,6 +72,6 @@ private:
     void InsertArgv();
     bool TrySetupSSLCertKey();
     bool TrySetupDsiWareSave();
-    bool TryDecryptSecureArea();
     bool TryFindDsiVerData();
+    bool TryDecryptSecureArea();
 };

--- a/arm7/source/loader/NdsLoader.h
+++ b/arm7/source/loader/NdsLoader.h
@@ -73,4 +73,5 @@ private:
     bool TrySetupSSLCertKey();
     bool TrySetupDsiWareSave();
     bool TryDecryptSecureArea();
+    bool TryFindDsiVerData();
 };

--- a/arm7/source/loader/NdsLoader.h
+++ b/arm7/source/loader/NdsLoader.h
@@ -70,6 +70,7 @@ private:
         char driveLetter, const char* deviceName, const char* path, u8 flags, u8 accessRights);
     void SetupDsiDeviceList();
     void InsertArgv();
+    bool TrySetupSSLCertKey();
     bool TrySetupDsiWareSave();
     bool TryDecryptSecureArea();
 };

--- a/arm7/source/loader/TwlAes.cpp
+++ b/arm7/source/loader/TwlAes.cpp
@@ -39,6 +39,20 @@ void TwlAes::SetupAes(const nds_header_twl_t* romHeader) const
     (&REG_AES_SEED0)[KEY_SLOT_NAND * 3].words[3] = NAND_KEYY_WORD_3;
 }
 
+void TwlAes::SetupKeySlot(u32 keySlot, const aes_u128_t* key) const
+{
+    REG_AES_CNT = 0;
+
+    aes_reset();
+    aes_reset();
+    aes_waitKeyBusy();
+
+    aes_setKey(keySlot, key);
+
+    aes_setKeySlot(keySlot);
+    aes_waitKeyBusy();
+}
+
 void TwlAes::DecryptModuleAes(void* data, u32 length, const aes_u128_t* iv) const
 {
     REG_AES_CNT = 0;

--- a/arm7/source/loader/TwlAes.h
+++ b/arm7/source/loader/TwlAes.h
@@ -16,6 +16,11 @@ public:
     /// @param iv The AES initialization vector.
     void DecryptModuleAes(void* data, u32 length, const aes_u128_t* iv) const;
 
+    /// @brief Sets a key into the specified key slot.
+    /// @param keySlot The key slot to configure.
+    /// @param key The 128-bit AES key to set.
+    void SetupKeySlot(u32 keySlot, const aes_u128_t* key) const;
+
 private:
     void SetupModuleKeyXY(const nds_header_twl_t* romHeader) const;
     void SetupNandKeyX() const;

--- a/arm9/source/Arm7Patcher.cpp
+++ b/arm9/source/Arm7Patcher.cpp
@@ -15,6 +15,7 @@
 #include "patches/arm7/DisableArm7WramClearPatch.h"
 #include "patches/arm7/sdk5/Sdk5DsiSdCardRedirectPatch.h"
 #include "patches/arm7/PokemonDownloaderArm7Patch.h"
+#include "patches/arm7/RedirectSoundFolderArm7Patch.h"
 #include "Arm7Patcher.h"
 
 void* Arm7Patcher::ApplyPatches(const LoaderPlatform* loaderPlatform) const
@@ -58,6 +59,11 @@ void* Arm7Patcher::ApplyPatches(const LoaderPlatform* loaderPlatform) const
             if (gIsDsiMode && (twlRomHeader->HasNandAccess() || twlRomHeader->HasSdAccess()))
             {
                 patchCollection.AddPatch(new Sdk5DsiSdCardRedirectPatch());
+            }
+
+            if (gIsDsiMode && twlRomHeader->HasShared2Access())
+            {
+                patchCollection.AddPatch(new RedirectSoundFolderArm7Patch());
             }
 
             if (!twlRomHeader->IsDsiWare())

--- a/arm9/source/patches/arm7/RedirectSoundFolderArm7Patch.cpp
+++ b/arm9/source/patches/arm7/RedirectSoundFolderArm7Patch.cpp
@@ -1,0 +1,32 @@
+#include "common.h"
+#include "../PatchContext.h"
+#include "RedirectSoundFolderArm7Patch.h"
+
+static const u32 sSoundFolderPathTextPattern[] = { 0x646E616Eu, 0x68732F3Au, 0x64657261u, 0x30252F32u };
+
+bool RedirectSoundFolderArm7Patch::FindPatchTarget(PatchContext& patchContext)
+{
+    _shared2PathOffset = patchContext.FindPattern32Twl(sSoundFolderPathTextPattern, sizeof(sSoundFolderPathTextPattern));;
+
+    if (_shared2PathOffset)
+    {
+        LOG_DEBUG("Arm7i shared2 path offset found at 0x%p\n", _shared2PathOffset);
+    }
+    else
+    {
+        LOG_WARNING("Arm7i shared2 path offset not found\n");
+    }
+
+    return _shared2PathOffset != nullptr;
+}
+
+void RedirectSoundFolderArm7Patch::ApplyPatch(PatchContext& patchContext)
+{
+    if (!_shared2PathOffset)
+        return;
+
+    _shared2PathOffset[0] = 0x2F3A6473; // "sd:/"
+    _shared2PathOffset[1] = 0x6369705F; // "_pic"
+    _shared2PathOffset[2] = 0x6E732F6F; // "o/sn"
+    _shared2PathOffset[3] = 0x30252F64; // "d/%0"
+}

--- a/arm9/source/patches/arm7/RedirectSoundFolderArm7Patch.h
+++ b/arm9/source/patches/arm7/RedirectSoundFolderArm7Patch.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "../Patch.h"
+
+/// @brief Arm7 patch to redirecting sound folder to our sub directory.
+class RedirectSoundFolderArm7Patch : public Patch
+{
+public:
+    bool FindPatchTarget(PatchContext& patchContext) override;
+    void ApplyPatch(PatchContext& patchContext) override;
+
+private:
+    u32* _shared2PathOffset = nullptr;
+};

--- a/common/ndsHeader.h
+++ b/common/ndsHeader.h
@@ -63,8 +63,9 @@ struct nds_header_ntr_t
 
 static_assert(sizeof(nds_header_ntr_t) == 0x170, "Invalid size for nds_header_ntr_t");
 
-#define NDS_HEADER_TWL_ACCESS_CONTROL_SD_ACCESS     (1 << 3)
-#define NDS_HEADER_TWL_ACCESS_CONTROL_NAND_ACCESS   (1 << 4)
+#define NDS_HEADER_TWL_ACCESS_CONTROL_SD_ACCESS      (1 << 3)
+#define NDS_HEADER_TWL_ACCESS_CONTROL_NAND_ACCESS    (1 << 4)
+#define NDS_HEADER_TWL_ACCESS_CONTROL_SHARED2_ACCESS (1 << 6)
 
 struct nds_header_twl_t : public nds_header_ntr_t
 {
@@ -145,6 +146,11 @@ struct nds_header_twl_t : public nds_header_ntr_t
     constexpr bool HasNandAccess() const
     {
         return IsTwlRom() && (accessControl & NDS_HEADER_TWL_ACCESS_CONTROL_NAND_ACCESS) != 0;
+    }
+
+    constexpr bool HasShared2Access() const
+    {
+        return IsTwlRom() && (accessControl & NDS_HEADER_TWL_ACCESS_CONTROL_SHARED2_ACCESS) != 0;
     }
 };
 

--- a/common/ndsHeader.h
+++ b/common/ndsHeader.h
@@ -66,6 +66,7 @@ static_assert(sizeof(nds_header_ntr_t) == 0x170, "Invalid size for nds_header_nt
 #define NDS_HEADER_TWL_ACCESS_CONTROL_SD_ACCESS      (1 << 3)
 #define NDS_HEADER_TWL_ACCESS_CONTROL_NAND_ACCESS    (1 << 4)
 #define NDS_HEADER_TWL_ACCESS_CONTROL_SHARED2_ACCESS (1 << 6)
+#define NDS_HEADER_TWL_ACCESS_CONTROL_SSLCERT_ACCESS (1 << 9)
 
 struct nds_header_twl_t : public nds_header_ntr_t
 {
@@ -151,6 +152,11 @@ struct nds_header_twl_t : public nds_header_ntr_t
     constexpr bool HasShared2Access() const
     {
         return IsTwlRom() && (accessControl & NDS_HEADER_TWL_ACCESS_CONTROL_SHARED2_ACCESS) != 0;
+    }
+
+    constexpr bool HasSSLCertAccess() const
+    {
+        return IsTwlRom() && (accessControl & NDS_HEADER_TWL_ACCESS_CONTROL_SSLCERT_ACCESS) != 0;
     }
 };
 

--- a/common/ndsHeader.h
+++ b/common/ndsHeader.h
@@ -78,7 +78,7 @@ struct nds_header_twl_t : public nds_header_ntr_t
     u32 regionFlags;
     u32 accessControl;
     u32 arm7ScfgExt7;
-    u8 gap1B8[3];
+    u8 gap1BC[3];
     u8 twlFlags2;
     u32 arm9iRomOffset;
     u8 gap1C4[4];


### PR DESCRIPTION
This PR close #36.
Multi nand support has been added. When booting a dsi rom with region CHN or KOR, the `_twlc` or `_twlk` directory is used instead of the original `_twln` directory.
This allows different region TWL font files to be used on a single device without requiring any patches to Virtual Filename Placeholders `<sharedFont>`. And also allows issue #32 to be closed.

Tested and works fine on: DSPico v1.3 + Firmware v1.0