### PR TITLE
Properly set the supported language, user language, and region based on the ROM's region

### DIFF
--- a/arm7/source/loader/ConsoleRegion.h
+++ b/arm7/source/loader/ConsoleRegion.h
@@ -1,0 +1,12 @@
+#pragma once
+
+/// @brief Enum for DSi console region.
+enum class ConsoleRegion
+{
+    Japan,
+    America,
+    Europe,
+    Australia,
+    China,
+    Korea
+};

--- a/arm7/source/loader/NdsLoader.cpp
+++ b/arm7/source/loader/NdsLoader.cpp
@@ -865,38 +865,9 @@ void NdsLoader::StartRom(BootMode bootMode)
 
 void NdsLoader::SetupTwlConfig()
 {
-    char romRegion = (_romHeader.gameCode >> 24) & 0xFF;
-    u8 newRegion = 2; // default region set to EUR, 2 = europe
-    if (romRegion != 'A' && romRegion != 'O')
-    {
-        // Determine region by TID
-        if (romRegion == 'J') {
-            newRegion = 0;
-        } else if (romRegion == 'E' || romRegion == 'T') {
-            newRegion = 1;
-        } else if (romRegion == 'P' || romRegion == 'V') {
-            // newRegion = 2;
-        } else if (romRegion == 'U') {
-            newRegion = 3;
-        } else if (romRegion == 'C') {
-            newRegion = 4;
-        } else if (romRegion== 'K') {
-            newRegion = 5;
-        }
-    }
-
-    u8 userLang = TWL_SHARED_MEMORY->ntrSharedMem.firmwareUserData[0x64];
+    u8 romRegion = getRomRegion((_romHeader.gameCode >> 24) & 0xFF);
     // Set language based on rom region, TODO: allow user to override this via some config or so
-    if (newRegion == 0)
-        userLang = 0;
-    else if (newRegion == 1 && (userLang != 1 || userLang != 2 || userLang != 5))
-        userLang = 1;
-    else if (newRegion == 2 && userLang < 1 && userLang > 5)
-        userLang = 1;
-    else if (newRegion == 4)
-        userLang = 6;
-    else if (newRegion == 5)
-        userLang = 7;
+    u8 userLang = getLanguageByRomRegion(romRegion);
 
     twl_config_t* twlConfig = (twl_config_t*)0x02000400;
     *(twl_config_t**)0x02FFFDFC = twlConfig;
@@ -913,7 +884,7 @@ void NdsLoader::SetupTwlConfig()
     twlConfig->alarmMinute = TWL_SHARED_MEMORY->ntrSharedMem.firmwareUserData[0x53];
     twlConfig->alarmEnable = TWL_SHARED_MEMORY->ntrSharedMem.firmwareUserData[0x56];
     twlConfig->systemMenuUsedTitleSlots = 9;
-    twlConfig->systemMenuUsedTitleSlots = 30;
+    twlConfig->systemMenuFreeTitleSlots = 30;
     twlConfig->field24 = 3;
     memcpy(&twlConfig->touchCalibrationX1Adc, &TWL_SHARED_MEMORY->ntrSharedMem.firmwareUserData[0x58], 0xC);
     twlConfig->field3C = 0x0201209C;
@@ -940,22 +911,9 @@ void NdsLoader::SetupTwlConfig()
     *(vu16*)0x020005E2 = swi_getCrc16(0xFFFF, (void*)0x020005E4, 0xC);
 
     // Set bitmask for supported languages
-    if (newRegion == 1) {
-        *(vu32*)0x02FFFD68 = 0x26; // USA
-    } else if (newRegion == 2) {
-        *(vu32*)0x02FFFD68 = 0x3E; // EUR
-    } else if (newRegion == 3) {
-        *(vu32*)0x02FFFD68 = 0x02; // AUS
-    } else if (newRegion == 4) {
-        *(vu32*)0x02FFFD68 = 0x40; // CHN
-    } else if (newRegion == 5) {
-        *(vu32*)0x02FFFD68 = 0x80; // KOR
-    } else if (newRegion == 0) {
-        *(vu32*)0x02FFFD68 = 0x01; // JAP
-    }
-
+    *(vu32*)0x02FFFD68 = getSupportedLanguagesByRegion(romRegion);
     *(vu32*)0x02FFFD6C = 0;
-    *(vu8*)0x02FFFD70 = newRegion; // region
+    *(vu8*)0x02FFFD70 = romRegion; // region
 }
 
 void NdsLoader::SetDeviceListEntry(dsi_devicelist_entry_t& deviceListEntry,
@@ -1057,4 +1015,99 @@ bool NdsLoader::TryDecryptSecureArea()
 
     LOG_DEBUG("Decrypted secure area\n");
     return true;
+}
+
+u8 NdsLoader::getRomRegion(char gameRegionCode)
+{
+    if (gameRegionCode != 'A' && gameRegionCode != 'O')
+    {
+        // Determine region by TID
+        if (gameRegionCode == 'J')
+        {
+            return JPN;
+        }
+        else if (gameRegionCode == 'E' || gameRegionCode == 'T')
+        {
+            return USA;
+        }
+        else if (gameRegionCode == 'P' || gameRegionCode == 'V')
+        {
+            return EUR;
+        }
+        else if (gameRegionCode == 'U')
+        {
+            return AUS;
+        }
+        else if (gameRegionCode == 'C')
+        {
+            return CHN;
+        }
+        else if (gameRegionCode== 'K')
+        {
+            return KOR;
+        }
+    }
+
+    return EUR; // Default to EUR
+}
+
+u8 NdsLoader::getLanguageByRomRegion(u8 romRegion)
+{
+    u8 userLang = TWL_SHARED_MEMORY->ntrSharedMem.firmwareUserData[0x64];
+
+    if (romRegion == JPN)
+    {
+        return JAPANESE;
+    }
+    else if (romRegion == USA && (userLang != ENGLISH || userLang != FRENCH || userLang != SPANISH))
+    {
+        return ENGLISH;
+    }
+    else if (romRegion == EUR && userLang < ENGLISH && userLang > SPANISH)
+    {
+        return ENGLISH;
+    }
+    else if (romRegion == CHN)
+    {
+        return CHINESE;
+    }
+    else if (romRegion == KOR)
+    {
+        return KOREAN;
+    }
+
+    return userLang;
+}
+
+u32 NdsLoader::getSupportedLanguagesByRegion(u8 region)
+{
+    switch (region)
+    {
+        case JPN:
+        {
+            return 0x01;
+        }
+        case USA:
+        {
+            return 0x26;
+        }
+        case EUR:
+        {
+            return 0x3E;
+        }
+        case AUS:
+        {
+            return 0x02;
+        }
+        case CHN:
+        {
+            return 0x40;
+        }
+        case KOR:
+        {
+            return 0x80;
+        }
+    }
+
+    return 0x3E;
 }

--- a/arm7/source/loader/NdsLoader.cpp
+++ b/arm7/source/loader/NdsLoader.cpp
@@ -865,9 +865,9 @@ void NdsLoader::StartRom(BootMode bootMode)
 
 void NdsLoader::SetupTwlConfig()
 {
-    u8 romRegion = getRomRegion((_romHeader.gameCode >> 24) & 0xFF);
+    ConsoleRegion romRegion = GetRomRegion((_romHeader.gameCode >> 24) & 0xFF);
     // Set language based on rom region, TODO: allow user to override this via some config or so
-    u8 userLang = getLanguageByRomRegion(romRegion);
+    UserLanguage userLang = GetLanguageByRomRegion(romRegion);
 
     twl_config_t* twlConfig = (twl_config_t*)0x02000400;
     *(twl_config_t**)0x02FFFDFC = twlConfig;
@@ -876,7 +876,7 @@ void NdsLoader::SetupTwlConfig()
     memset(twlConfig, 0, sizeof(twl_config_t));
     twlConfig->configFlags = 0x0100000F;
     twlConfig->country = 0x4E;
-    twlConfig->language = userLang;
+    twlConfig->language = static_cast<u8>(userLang);
     twlConfig->rtcYear = TWL_SHARED_MEMORY->ntrSharedMem.firmwareUserData[0x66];
     twlConfig->rtcOffset = *(s64*)&TWL_SHARED_MEMORY->ntrSharedMem.firmwareUserData[0x68];
     twlConfig->eulaAgreeVersion[0] = 1;
@@ -911,9 +911,9 @@ void NdsLoader::SetupTwlConfig()
     *(vu16*)0x020005E2 = swi_getCrc16(0xFFFF, (void*)0x020005E4, 0xC);
 
     // Set bitmask for supported languages
-    *(vu32*)0x02FFFD68 = getSupportedLanguagesByRegion(romRegion);
+    *(vu32*)0x02FFFD68 = GetSupportedLanguagesByRegion(romRegion);
     *(vu32*)0x02FFFD6C = 0;
-    *(vu8*)0x02FFFD70 = romRegion; // region
+    *(vu8*)0x02FFFD70 = static_cast<u8>(romRegion); // region
 }
 
 void NdsLoader::SetDeviceListEntry(dsi_devicelist_entry_t& deviceListEntry,
@@ -1017,93 +1017,96 @@ bool NdsLoader::TryDecryptSecureArea()
     return true;
 }
 
-u8 NdsLoader::getRomRegion(char gameRegionCode)
+ConsoleRegion NdsLoader::GetRomRegion(char gameRegionCode)
 {
     if (gameRegionCode != 'A' && gameRegionCode != 'O')
     {
         // Determine region by TID
         if (gameRegionCode == 'J')
         {
-            return JPN;
+            return ConsoleRegion::Japan;
         }
         else if (gameRegionCode == 'E' || gameRegionCode == 'T')
         {
-            return USA;
+            return ConsoleRegion::America;
         }
         else if (gameRegionCode == 'P' || gameRegionCode == 'V')
         {
-            return EUR;
+            return ConsoleRegion::Europe;
         }
         else if (gameRegionCode == 'U')
         {
-            return AUS;
+            return ConsoleRegion::Australia;
         }
         else if (gameRegionCode == 'C')
         {
-            return CHN;
+            return ConsoleRegion::China;
         }
         else if (gameRegionCode== 'K')
         {
-            return KOR;
+            return ConsoleRegion::Korea;
         }
     }
 
-    return EUR; // Default to EUR
+    return ConsoleRegion::Europe; // Default to EUR
 }
 
-u8 NdsLoader::getLanguageByRomRegion(u8 romRegion)
+UserLanguage NdsLoader::GetLanguageByRomRegion(ConsoleRegion romRegion)
 {
-    u8 userLang = (TWL_SHARED_MEMORY->ntrSharedMem.firmwareUserData[0x64] & 0x07);
+    UserLanguage userLang = static_cast<UserLanguage>(TWL_SHARED_MEMORY->ntrSharedMem.firmwareUserData[0x64] & 0x07);
 
-    if (romRegion == JPN)
+    if (romRegion == ConsoleRegion::Japan)
     {
-        return JAPANESE;
+        return UserLanguage::Japanese;
     }
-    else if (romRegion == USA && (userLang != ENGLISH || userLang != FRENCH || userLang != SPANISH))
+    else if (romRegion == ConsoleRegion::America &&
+            (userLang != UserLanguage::English ||
+             userLang != UserLanguage::French ||
+             userLang != UserLanguage::Spanish))
     {
-        return ENGLISH;
+        return UserLanguage::English;
     }
-    else if (romRegion == EUR && userLang < ENGLISH && userLang > SPANISH)
+    else if (romRegion == ConsoleRegion::Europe && userLang < UserLanguage::English && userLang > UserLanguage::Spanish)
     {
-        return ENGLISH;
+        return UserLanguage::English;
     }
-    else if (romRegion == CHN)
+    else if (romRegion == ConsoleRegion::China)
     {
-        return CHINESE;
+        return UserLanguage::Chinese;
     }
-    else if (romRegion == KOR)
+    else if (romRegion == ConsoleRegion::Korea)
     {
-        return KOREAN;
+        return UserLanguage::Korean;
     }
 
     return userLang;
 }
 
-u32 NdsLoader::getSupportedLanguagesByRegion(u8 region)
+u32 NdsLoader::GetSupportedLanguagesByRegion(ConsoleRegion region)
 {
     switch (region)
     {
-        case JPN:
+        case ConsoleRegion::Japan:
         {
             return 0x01;
         }
-        case USA:
+        case ConsoleRegion::America:
         {
             return 0x26;
         }
-        case EUR:
+        case ConsoleRegion::Europe:
         {
             return 0x3E;
         }
-        case AUS:
+        case ConsoleRegion::Australia:
         {
             return 0x02;
         }
-        case CHN:
+        case ConsoleRegion::China:
         {
             return 0x40;
         }
-        case KOR:
+        case ConsoleRegion::Korea:
         {
             return 0x80;
         }

--- a/arm7/source/loader/NdsLoader.cpp
+++ b/arm7/source/loader/NdsLoader.cpp
@@ -865,6 +865,39 @@ void NdsLoader::StartRom(BootMode bootMode)
 
 void NdsLoader::SetupTwlConfig()
 {
+    char romRegion = (_romHeader.gameCode >> 24) & 0xFF;
+    u8 newRegion = 2; // default region set to EUR, 2 = europe
+    if (romRegion != 'A' && romRegion != 'O')
+    {
+        // Determine region by TID
+        if (romRegion == 'J') {
+            newRegion = 0;
+        } else if (romRegion == 'E' || romRegion == 'T') {
+            newRegion = 1;
+        } else if (romRegion == 'P' || romRegion == 'V') {
+            // newRegion = 2;
+        } else if (romRegion == 'U') {
+            newRegion = 3;
+        } else if (romRegion == 'C') {
+            newRegion = 4;
+        } else if (romRegion== 'K') {
+            newRegion = 5;
+        }
+    }
+
+    u8 userLang = TWL_SHARED_MEMORY->ntrSharedMem.firmwareUserData[0x64];
+    // Set language based on rom region, TODO: allow user to override this via some config or so
+    if (newRegion == 0)
+        userLang = 0;
+    else if (newRegion == 1 && (userLang != 1 || userLang != 2 || userLang != 5))
+        userLang = 1;
+    else if (newRegion == 2 && userLang < 1 && userLang > 5)
+        userLang = 1;
+    else if (newRegion == 4)
+        userLang = 6;
+    else if (newRegion == 5)
+        userLang = 7;
+
     twl_config_t* twlConfig = (twl_config_t*)0x02000400;
     *(twl_config_t**)0x02FFFDFC = twlConfig;
     *(vu8*)0x02FFFDFA = 0x80;
@@ -872,7 +905,7 @@ void NdsLoader::SetupTwlConfig()
     memset(twlConfig, 0, sizeof(twl_config_t));
     twlConfig->configFlags = 0x0100000F;
     twlConfig->country = 0x4E;
-    twlConfig->language = TWL_SHARED_MEMORY->ntrSharedMem.firmwareUserData[0x64];
+    twlConfig->language = userLang;
     twlConfig->rtcYear = TWL_SHARED_MEMORY->ntrSharedMem.firmwareUserData[0x66];
     twlConfig->rtcOffset = *(s64*)&TWL_SHARED_MEMORY->ntrSharedMem.firmwareUserData[0x68];
     twlConfig->eulaAgreeVersion[0] = 1;
@@ -906,9 +939,23 @@ void NdsLoader::SetupTwlConfig()
     }
     *(vu16*)0x020005E2 = swi_getCrc16(0xFFFF, (void*)0x020005E4, 0xC);
 
-    *(vu32*)0x02FFFD68 = 0x3E; // supported languages
+    // Set bitmask for supported languages
+    if (newRegion == 1) {
+        *(vu32*)0x02FFFD68 = 0x26; // USA
+    } else if (newRegion == 2) {
+        *(vu32*)0x02FFFD68 = 0x3E; // EUR
+    } else if (newRegion == 3) {
+        *(vu32*)0x02FFFD68 = 0x02; // AUS
+    } else if (newRegion == 4) {
+        *(vu32*)0x02FFFD68 = 0x40; // CHN
+    } else if (newRegion == 5) {
+        *(vu32*)0x02FFFD68 = 0x80; // KOR
+    } else if (newRegion == 0) {
+        *(vu32*)0x02FFFD68 = 0x01; // JAP
+    }
+
     *(vu32*)0x02FFFD6C = 0;
-    *(vu8*)0x02FFFD70 = 2; // region, 2 = europe
+    *(vu8*)0x02FFFD70 = newRegion; // region
 }
 
 void NdsLoader::SetDeviceListEntry(dsi_devicelist_entry_t& deviceListEntry,

--- a/arm7/source/loader/NdsLoader.cpp
+++ b/arm7/source/loader/NdsLoader.cpp
@@ -865,7 +865,7 @@ void NdsLoader::StartRom(BootMode bootMode)
 
 void NdsLoader::SetupTwlConfig()
 {
-    ConsoleRegion romRegion = GetRomRegion((_romHeader.gameCode >> 24) & 0xFF);
+    ConsoleRegion romRegion = GetRomRegion(_romHeader.gameCode);
     // Set language based on rom region, TODO: allow user to override this via some config or so
     UserLanguage userLang = GetLanguageByRomRegion(romRegion);
 
@@ -1017,8 +1017,9 @@ bool NdsLoader::TryDecryptSecureArea()
     return true;
 }
 
-ConsoleRegion NdsLoader::GetRomRegion(char gameRegionCode)
+ConsoleRegion NdsLoader::GetRomRegion(u32 gameCode)
 {
+    u8 gameRegionCode = (gameCode >> 24) & 0xFF;
     if (gameRegionCode != 'A' && gameRegionCode != 'O')
     {
         // Determine region by TID

--- a/arm7/source/loader/NdsLoader.cpp
+++ b/arm7/source/loader/NdsLoader.cpp
@@ -1053,7 +1053,7 @@ u8 NdsLoader::getRomRegion(char gameRegionCode)
 
 u8 NdsLoader::getLanguageByRomRegion(u8 romRegion)
 {
-    u8 userLang = TWL_SHARED_MEMORY->ntrSharedMem.firmwareUserData[0x64];
+    u8 userLang = (TWL_SHARED_MEMORY->ntrSharedMem.firmwareUserData[0x64] & 0x07);
 
     if (romRegion == JPN)
     {

--- a/arm7/source/loader/NdsLoader.h
+++ b/arm7/source/loader/NdsLoader.h
@@ -74,7 +74,7 @@ private:
     void InsertArgv();
     bool TrySetupDsiWareSave();
     bool TryDecryptSecureArea();
-    ConsoleRegion GetRomRegion(char gameRegionCode);
+    ConsoleRegion GetRomRegion(u32 gameCode);
     UserLanguage GetLanguageByRomRegion(ConsoleRegion romRegion);
     u32 GetSupportedLanguagesByRegion(ConsoleRegion region);
 };

--- a/arm7/source/loader/NdsLoader.h
+++ b/arm7/source/loader/NdsLoader.h
@@ -6,6 +6,30 @@
 
 struct dsi_devicelist_entry_t;
 
+/// @brief Enum for DSi console region.
+typedef enum
+{
+    JPN,
+    USA,
+    EUR,
+    AUS,
+    CHN,
+    KOR
+} ConsoleRegion;
+
+/// @brief Enum for DSi user language.
+typedef enum
+{
+    JAPANESE,
+    ENGLISH,
+    FRENCH,
+    GERMAN,
+    ITALIAN,
+    SPANISH,
+    CHINESE,
+    KOREAN
+} UserLanguage;
+
 /// @brief Class for loading DS(i) roms.
 class NdsLoader
 {
@@ -72,4 +96,7 @@ private:
     void InsertArgv();
     bool TrySetupDsiWareSave();
     bool TryDecryptSecureArea();
+    u8 getRomRegion(char gameRegionCode);
+    u8 getLanguageByRomRegion(u8 romRegion);
+    u32 getSupportedLanguagesByRegion(u8 region);
 };

--- a/arm7/source/loader/NdsLoader.h
+++ b/arm7/source/loader/NdsLoader.h
@@ -3,32 +3,10 @@
 #include "ndsHeader.h"
 #include "DsiWareSaveArranger.h"
 #include "BootMode.h"
+#include "ConsoleRegion.h"
+#include "UserLanguage.h"
 
 struct dsi_devicelist_entry_t;
-
-/// @brief Enum for DSi console region.
-typedef enum
-{
-    JPN,
-    USA,
-    EUR,
-    AUS,
-    CHN,
-    KOR
-} ConsoleRegion;
-
-/// @brief Enum for DSi user language.
-typedef enum
-{
-    JAPANESE,
-    ENGLISH,
-    FRENCH,
-    GERMAN,
-    ITALIAN,
-    SPANISH,
-    CHINESE,
-    KOREAN
-} UserLanguage;
 
 /// @brief Class for loading DS(i) roms.
 class NdsLoader
@@ -96,7 +74,7 @@ private:
     void InsertArgv();
     bool TrySetupDsiWareSave();
     bool TryDecryptSecureArea();
-    u8 getRomRegion(char gameRegionCode);
-    u8 getLanguageByRomRegion(u8 romRegion);
-    u32 getSupportedLanguagesByRegion(u8 region);
+    ConsoleRegion GetRomRegion(char gameRegionCode);
+    UserLanguage GetLanguageByRomRegion(ConsoleRegion romRegion);
+    u32 GetSupportedLanguagesByRegion(ConsoleRegion region);
 };

--- a/arm7/source/loader/UserLanguage.h
+++ b/arm7/source/loader/UserLanguage.h
@@ -1,0 +1,14 @@
+#pragma once
+
+/// @brief Enum for DSi user language.
+enum class UserLanguage
+{
+    Japanese,
+    English,
+    French,
+    German,
+    Italian,
+    Spanish,
+    Chinese,
+    Korean
+};


### PR DESCRIPTION
Automatically select TWLCFG's language, region, and supported language based on ROM region on `SetupTwlConfig` function.
This bypasses the region lock or language lock in some dsiware games.
In the future, we can also introduce configuration options to allow users to specify and override these settings in Pico Launcher.

Tested and works fine on: DSPico v1.3 + Firmware v1.0