### PR TITLE
Impl `HandleiQueRegionFreePatching` to bypass region locking on certain iQue games

### DIFF
--- a/arm7/source/loader/NdsLoader.cpp
+++ b/arm7/source/loader/NdsLoader.cpp
@@ -220,6 +220,7 @@ void NdsLoader::Load(BootMode bootMode)
     if (bootMode == BootMode::Normal)
     {
         bootType = _romHeader.IsDsiWare() ? BOOT_TYPE_NAND : BOOT_TYPE_CARD;
+        HandleiQueRegionFreePatching();
     }
     else if (bootMode == BootMode::Multiboot)
     {
@@ -1011,6 +1012,15 @@ bool NdsLoader::TryDecryptSecureArea()
 
     LOG_DEBUG("Decrypted secure area\n");
     return true;
+}
+
+void NdsLoader::HandleiQueRegionFreePatching()
+{
+    if ((_romHeader.ndsRegion & 0x80) == 0x80)
+    {
+        _romHeader.ndsRegion = 0;
+        _romHeader.headerCrc = swi_getCrc16(0xFFFF, (void*)&_romHeader, 0x15E);
+    }
 }
 
 ConsoleRegion NdsLoader::GetRomRegion(u32 gameCode)

--- a/arm7/source/loader/NdsLoader.cpp
+++ b/arm7/source/loader/NdsLoader.cpp
@@ -1014,11 +1014,11 @@ bool NdsLoader::TryDecryptSecureArea()
     return true;
 }
 
-void NdsLoader::HandleiQueRegionFreePatching()
+void NdsLoader::HandleIQueRegionFreePatching()
 {
-    if ((_romHeader.ndsRegion & 0x80) == 0x80)
+    if ((_romHeader.flags & 0x80) == 0x80)
     {
-        _romHeader.ndsRegion = 0;
+        _romHeader.flags &= ~0x80;
         _romHeader.headerCrc = swi_getCrc16(0xFFFF, (void*)&_romHeader, 0x15E);
     }
 }

--- a/arm7/source/loader/NdsLoader.cpp
+++ b/arm7/source/loader/NdsLoader.cpp
@@ -220,7 +220,7 @@ void NdsLoader::Load(BootMode bootMode)
     if (bootMode == BootMode::Normal)
     {
         bootType = _romHeader.IsDsiWare() ? BOOT_TYPE_NAND : BOOT_TYPE_CARD;
-        HandleiQueRegionFreePatching();
+        HandleIQueRegionFreePatching();
     }
     else if (bootMode == BootMode::Multiboot)
     {

--- a/arm7/source/loader/NdsLoader.h
+++ b/arm7/source/loader/NdsLoader.h
@@ -73,7 +73,7 @@ private:
     void InsertArgv();
     bool TrySetupDsiWareSave();
     bool TryDecryptSecureArea();
-    void HandleiQueRegionFreePatching();
+    void HandleIQueRegionFreePatching();
     ConsoleRegion GetRomRegion(u32 gameCode);
     UserLanguage GetLanguageByRomRegion(ConsoleRegion romRegion);
     u32 GetSupportedLanguagesByRegion(ConsoleRegion region);

--- a/arm7/source/loader/NdsLoader.h
+++ b/arm7/source/loader/NdsLoader.h
@@ -73,6 +73,7 @@ private:
     void InsertArgv();
     bool TrySetupDsiWareSave();
     bool TryDecryptSecureArea();
+    void HandleiQueRegionFreePatching();
     ConsoleRegion GetRomRegion(u32 gameCode);
     UserLanguage GetLanguageByRomRegion(ConsoleRegion romRegion);
     u32 GetSupportedLanguagesByRegion(ConsoleRegion region);

--- a/common/ndsHeader.h
+++ b/common/ndsHeader.h
@@ -11,9 +11,9 @@ struct nds_header_ntr_t
     u8 deviceCapacity;
     u8 gap15[7];
     u8 twlFlags;
-    u8 ndsRegion;
+    u8 flags;
     u8 softwareVersion;
-    u8 autoBootFlags;
+    u8 flags2;
     u32 arm9RomOffset;
     u32 arm9EntryAddress;
     u32 arm9LoadAddress;

--- a/common/ndsHeader.h
+++ b/common/ndsHeader.h
@@ -11,9 +11,9 @@ struct nds_header_ntr_t
     u8 deviceCapacity;
     u8 gap15[7];
     u8 twlFlags;
-    u8 flags;
+    u8 ndsRegion;
     u8 softwareVersion;
-    u8 flags2;
+    u8 autoBootFlags;
     u32 arm9RomOffset;
     u32 arm9EntryAddress;
     u32 arm9LoadAddress;


### PR DESCRIPTION
The iQue cartridge games and some certain iQue DSiWare titles contain additional region-locking logic that checks the value at offset 0x1D in the file header.
Fortunately, both DS cartridge games and DSiWare use the same validation method for this check; the only difference lies in how the software behaves once the region lock is triggered.
For example, in the iQue version of `New Super Mario Bros`, the game jumps to an error screen. In contrast, `DSi Sound` continues to function normally, except that the touch screen becomes non-functional.
This PR resolves the region lock by modifying the value at offset 0x1D in the file header.
The patch is applied before `SetupSharedMemory` is called, ensuring that the header copied into shared memory is already patched.