### PR TITLE
Handle BLX branches in CardiTryReadCardDmaPatch

### DIFF
--- a/arm9/source/patches/arm9/sdk2to4/CardiTryReadCardDmaPatch.cpp
+++ b/arm9/source/patches/arm9/sdk2to4/CardiTryReadCardDmaPatch.cpp
@@ -167,7 +167,7 @@ bool CardiTryReadCardDmaPatch::FindPatchTarget(PatchContext& patchContext)
 static u32 getArmBlAddress(const u32* instructionPointer)
 {
     u32 blInstruction = *instructionPointer;
-    return (u32)instructionPointer + 8 + ((int)((blInstruction & 0xFFFFFF) << 8) >> 6);
+    return (u32)instructionPointer + 8 + ((int)((blInstruction & 0xFFFFFF) << 8) >> 6) + ((blInstruction >> 24) == 0xFA ? 1 : 0);
 }
 
 void CardiTryReadCardDmaPatch::ApplyPatch(PatchContext& patchContext)


### PR DESCRIPTION
Add +1 to the resulting address if the call is a `blx` immediate. Closes #45 