### PR TITLE
Fix multiple matching signatures for SDK 3.1 card DMA

### DIFF
--- a/arm9/source/patches/arm9/sdk2to4/CardiTryReadCardDmaPatch.cpp
+++ b/arm9/source/patches/arm9/sdk2to4/CardiTryReadCardDmaPatch.cpp
@@ -228,7 +228,14 @@ void CardiTryReadCardDmaPatch::ApplyPatch(PatchContext& patchContext)
             {
                 cardiCommon = *(u32*)((u8*)_cardiTryReadCardDma + 0x15C) + 4;
                 cardiOnReadCard = *(u32*)((u8*)_cardiTryReadCardDma + 0x16C);
-                cardiSetCardDma = getArmBlAddress((u32*)((u8*)_cardiTryReadCardDma + 0x148));
+                if (*(u32*)((u8*)_cardiTryReadCardDma + 0x158) == 0xE12FFF1E)
+                {
+                    cardiSetCardDma = getArmBlAddress((u32*)((u8*)_cardiTryReadCardDma + 0x148));
+                }
+                else
+                {
+                    cardiSetCardDma = getArmBlAddress((u32*)((u8*)_cardiTryReadCardDma + 0x14C));
+                }
                 miiCardDmaCopy32 = getArmBlAddress((u32*)(cardiSetCardDma + 0x18));
                 cardiOnReadCardOffset = 0x40;
             }


### PR DESCRIPTION
Fixes:
- Unou no Tatsujin - Soukai! Machigai Museum 2 (Japan)
- Trioncube (Europe) (En,Fr,De,Es,It)
- Tetris DS (Korea)
- Original Frisbee Disc Sports - Ultimate & Golf (USA)
    - Closes #59 
- LifeSigns - Surgical Unit (USA)
    - Closes #57 