### PR TITLE
Patch checksum AP in Last Window: The Secret of Cape West

### DIFF
--- a/arm9/source/Arm9Patcher.cpp
+++ b/arm9/source/Arm9Patcher.cpp
@@ -13,6 +13,7 @@
 #include "patches/arm9/OSResetSystemPatch.h"
 #include "patches/arm9/PokemonDownloaderArm9Patch.h"
 #include "patches/arm9/DSProtectArm9Patch.h"
+#include "patches/arm9/LastWindowCrcPatch.h"
 #include "patches/arm9/NandSave/FaceTrainingNandSavePatch.h"
 #include "patches/arm9/NandSave/JamWithTheBandNandSavePatch.h"
 #include "patches/arm9/NandSave/NintendoDSGuideNandSavePatch.h"
@@ -405,6 +406,12 @@ void Arm9Patcher::AddGameSpecificPatches(
         case GAMECODE("UGDA"):
         {
             patchCollection.AddPatch(new NintendoDSGuideNandSavePatch());
+            break;
+        }
+        // Last Window: The Secret of Cape West
+        case GAMECODE("YLUP"):
+        {
+            patchCollection.AddPatch(new LastWindowCrcPatch());
             break;
         }
         // Rabbids Go Home

--- a/arm9/source/patches/arm9/LastWindowCrcPatch.cpp
+++ b/arm9/source/patches/arm9/LastWindowCrcPatch.cpp
@@ -1,0 +1,27 @@
+#include "common.h"
+#include "patches/PatchContext.h"
+#include "LastWindowCrcPatchCode.h"
+#include "LastWindowCrcPatch.h"
+
+bool LastWindowCrcPatch::FindPatchTarget(PatchContext& patchContext)
+{
+    u32* expectedLocation = (u32*)0x020304B4;
+    if (*expectedLocation == 0xFAFF4008) // blx SVC_GetCRC16
+    {
+        _getCrc16 = expectedLocation;
+    }
+
+    return true;
+}
+
+void LastWindowCrcPatch::ApplyPatch(PatchContext& patchContext)
+{
+    if (!_getCrc16)
+    {
+        return;
+    }
+
+    auto patchCode = patchContext.GetPatchCodeCollection().AddUniquePatchCode<LastWindowCrcPatchCode>(patchContext.GetPatchHeap());
+    *_getCrc16 = patchCode->MakeLastWindowCrcBlx((u32)_getCrc16);
+}
+

--- a/arm9/source/patches/arm9/LastWindowCrcPatch.cpp
+++ b/arm9/source/patches/arm9/LastWindowCrcPatch.cpp
@@ -5,23 +5,14 @@
 
 bool LastWindowCrcPatch::FindPatchTarget(PatchContext& patchContext)
 {
-    u32* expectedLocation = (u32*)0x020304B4;
-    if (*expectedLocation == 0xFAFF4008) // blx SVC_GetCRC16
-    {
-        _getCrc16 = expectedLocation;
-    }
-
+    _getCrc16 = (u32*)0x020304B4;
     return true;
 }
 
 void LastWindowCrcPatch::ApplyPatch(PatchContext& patchContext)
 {
-    if (!_getCrc16)
-    {
-        return;
-    }
-
     auto patchCode = patchContext.GetPatchCodeCollection().AddUniquePatchCode<LastWindowCrcPatchCode>(patchContext.GetPatchHeap());
-    *_getCrc16 = patchCode->MakeLastWindowCrcBlx((u32)_getCrc16);
+    u32 patchAddr = (u32)patchCode->GetLastWindowCrcFunction();
+    *_getCrc16 = MakeBlxCall(patchAddr);
 }
 

--- a/arm9/source/patches/arm9/LastWindowCrcPatch.h
+++ b/arm9/source/patches/arm9/LastWindowCrcPatch.h
@@ -32,4 +32,9 @@ public:
 
 private:
     u32* _getCrc16 = nullptr;
+
+    u32 MakeBlxCall(u32 patchAddr)
+    {
+        return 0xFA000000 | (((patchAddr - (u32)_getCrc16 - 8) >> 2) & 0xFFFFFF);
+    }
 };

--- a/arm9/source/patches/arm9/LastWindowCrcPatch.h
+++ b/arm9/source/patches/arm9/LastWindowCrcPatch.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "../Patch.h"
 
-/// @brief Arm9 patch for intercepting calls SVC_GetCRC16 in The Last Window: The Secret of Cape West
+/// @brief Arm9 patch for intercepting calls to SVC_GetCRC16 in The Last Window: The Secret of Cape West
 /// @details
 /// This game has DS Protect 1.27, which is patched by the regular DS Protect patches, but also has
 /// an extra layer of CRC checks that must match or the game will fail to boot.

--- a/arm9/source/patches/arm9/LastWindowCrcPatch.h
+++ b/arm9/source/patches/arm9/LastWindowCrcPatch.h
@@ -1,0 +1,33 @@
+#pragma once
+#include "../Patch.h"
+
+/// @brief Arm9 patch for intercepting calls SVC_GetCRC16 in The Last Window: The Secret of Cape West
+/// @details
+/// This game has DS Protect 1.27, which is patched by the regular DS Protect patches, but also has
+/// an extra layer of CRC checks that must match or the game will fail to boot.
+///
+/// It first runs DS Protect NotA1 at startup, and then does a CRC of most of DS Protect. This can
+/// tell which DS Protect functions were run, because at decrypt-run-encrypt, the key gets changed.
+/// So the CRC is sensitive not only to code modifications, but also to which encrypted functions
+/// were run, and how many times they were run.
+///
+/// The current DS Protect patch modifies NotA1, causes one of its subfunction to run twice, and
+/// the other subfunction to not be run, which obviously breaks the CRC.
+///
+/// Another region is also CRCed, from 0202DB34 to 02030334. What resides here is unknown, it does not
+/// contain any commonly modified functions such as AP or card reading.
+///
+/// To make things more annoying, the memory location of the correct CRC is randomized, and the code
+/// that checks the CRC resides in a compressed overlay which is loaded into ITCM.
+///
+/// Instead, the function call that calculates the CRC is shimmed and if its arguments match
+/// a problematic CRC calculation, the expected answer is returned instead.
+class LastWindowCrcPatch : public Patch
+{
+public:
+    bool FindPatchTarget(PatchContext& patchContext) override;
+    void ApplyPatch(PatchContext& patchContext) override;
+
+private:
+    u32* _getCrc16 = nullptr;
+};

--- a/arm9/source/patches/arm9/LastWindowCrcPatch.h
+++ b/arm9/source/patches/arm9/LastWindowCrcPatch.h
@@ -33,7 +33,7 @@ public:
 private:
     u32* _getCrc16 = nullptr;
 
-    u32 MakeBlxCall(u32 patchAddr)
+    u32 MakeBlxCall(u32 patchAddr) const
     {
         return 0xFA000000 | (((patchAddr - (u32)_getCrc16 - 8) >> 2) & 0xFFFFFF);
     }

--- a/arm9/source/patches/arm9/LastWindowCrcPatch.h
+++ b/arm9/source/patches/arm9/LastWindowCrcPatch.h
@@ -18,7 +18,9 @@
 /// contain any commonly modified functions such as AP or card reading.
 ///
 /// To make things more annoying, the memory location of the correct CRC is randomized, and the code
-/// that checks the CRC resides in a compressed overlay which is loaded into ITCM.
+/// that checks the CRC resides in a compressed overlay which is loaded into ITCM. This same function
+/// also receives several dummy checks that are expected to fail, and so cannot be patched to always
+/// report the CRC matches.
 ///
 /// Instead, the function call that calculates the CRC is shimmed and if its arguments match
 /// a problematic CRC calculation, the expected answer is returned instead.

--- a/arm9/source/patches/arm9/LastWindowCrcPatchCode.h
+++ b/arm9/source/patches/arm9/LastWindowCrcPatchCode.h
@@ -1,0 +1,21 @@
+#pragma once
+#include "../PatchCode.h"
+#include "sections.h"
+
+DEFINE_SECTION_SYMBOLS(patch_lastwindowcrc);
+
+extern "C" void patch_lastwindowcrc_entry(void);
+
+class LastWindowCrcPatchCode : public PatchCode
+{
+public:
+    LastWindowCrcPatchCode(PatchHeap& patchHeap)
+        : PatchCode(SECTION_START(patch_lastwindowcrc), SECTION_SIZE(patch_lastwindowcrc), patchHeap)
+    { }
+
+    const u32 MakeLastWindowCrcBlx(u32 calleeAddr) const
+    {
+        u32 addr = (u32)GetAddressAtTarget((void*)patch_lastwindowcrc_entry);
+        return 0xFA000000 | (((addr - calleeAddr - 8) >> 2) & 0xFFFFFF);
+    }
+};

--- a/arm9/source/patches/arm9/LastWindowCrcPatchCode.h
+++ b/arm9/source/patches/arm9/LastWindowCrcPatchCode.h
@@ -13,9 +13,8 @@ public:
         : PatchCode(SECTION_START(patch_lastwindowcrc), SECTION_SIZE(patch_lastwindowcrc), patchHeap)
     { }
 
-    const u32 MakeLastWindowCrcBlx(u32 callerAddr) const
+    const void* GetLastWindowCrcFunction() const
     {
-        u32 addr = (u32)GetAddressAtTarget((void*)patch_lastwindowcrc_entry);
-        return 0xFA000000 | (((addr - callerAddr - 8) >> 2) & 0xFFFFFF);
+        return GetAddressAtTarget((void*)patch_lastwindowcrc_entry);
     }
 };

--- a/arm9/source/patches/arm9/LastWindowCrcPatchCode.h
+++ b/arm9/source/patches/arm9/LastWindowCrcPatchCode.h
@@ -13,9 +13,9 @@ public:
         : PatchCode(SECTION_START(patch_lastwindowcrc), SECTION_SIZE(patch_lastwindowcrc), patchHeap)
     { }
 
-    const u32 MakeLastWindowCrcBlx(u32 calleeAddr) const
+    const u32 MakeLastWindowCrcBlx(u32 callerAddr) const
     {
         u32 addr = (u32)GetAddressAtTarget((void*)patch_lastwindowcrc_entry);
-        return 0xFA000000 | (((addr - calleeAddr - 8) >> 2) & 0xFFFFFF);
+        return 0xFA000000 | (((addr - callerAddr - 8) >> 2) & 0xFFFFFF);
     }
 };

--- a/arm9/source/patches/arm9/LastWindowCrcPatchCode.s
+++ b/arm9/source/patches/arm9/LastWindowCrcPatchCode.s
@@ -1,0 +1,29 @@
+.cpu arm946e-s
+.section "patch_lastwindowcrc", "ax"
+.syntax unified
+
+.thumb
+.global patch_lastwindowcrc_entry
+.type patch_lastwindowcrc_entry, %function
+patch_lastwindowcrc_entry:
+    ldr r3, =0x0207D4F4 // CRC of DS Protect region
+    cmp r1, r3
+    beq crc_dsprotect
+
+    ldr r3, =0x0207D4F4 // CRC of other code region (unknown)
+    cmp r1, r3
+    beq crc_unk
+
+    swi #0xE // Normal CRC if address does not match
+    bx lr
+
+crc_dsprotect:
+    ldr r0, =0x67D7
+    bx lr
+
+crc_unk:
+    ldr r0, =0x0D1E
+    bx lr
+
+.pool
+.end

--- a/arm9/source/patches/arm9/LastWindowCrcPatchCode.s
+++ b/arm9/source/patches/arm9/LastWindowCrcPatchCode.s
@@ -6,15 +6,16 @@
 .global patch_lastwindowcrc_entry
 .type patch_lastwindowcrc_entry, %function
 patch_lastwindowcrc_entry:
+    // r0=crc_start, r1=datap, r2=size
     ldr r3, =0x0207D4F4 // CRC of DS Protect region
     cmp r1, r3
     beq crc_dsprotect
 
-    ldr r3, =0x0207D4F4 // CRC of other code region (unknown)
+    ldr r3, =0x0202DB34 // CRC of other code region (unknown)
     cmp r1, r3
     beq crc_unk
 
-    swi #0xE // Normal CRC if address does not match
+    swi #0xE // Normal CRC if address does not match (never hit?)
     bx lr
 
 crc_dsprotect:


### PR DESCRIPTION
This game takes checksums of two regions of memory and will fail to boot if either mismatch. The patch inserts a function to shim the CRC calculation and return the intended results. This is very similar to the existing AP-fix available for this title, but with simplified code and the DS Protect patches removed. Closes #94 