### PR TITLE
Move emunand to subdirectory `_pico`, impl multi nand support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Pico Loader is a homebrew and retail DS(i) rom loader supporting a variety of pl
 ## Features
 - Supports both homebrew and retail DS(i) roms
 - Supports DSiWare and redirects NAND to the flashcard SD card (acting as "emunand", see below for how to setup)
+- Supports multi-region emunand (Standard, CHN and KOR)
 - Supports DS roms with an encrypted secure area if a DS arm7 bios is present at `/_pico/biosnds7.rom`
 - Supports a wide range of platforms, including popular flashcards and the DSpico
 - Built-in patches for DS Protect
@@ -62,25 +63,34 @@ The steps provided will assume you already have one of those environments set up
     - `savelist.bin` (generated in the `data` folder of the repo)
 
 ## Emunand
-When running DSiWare, Pico Loader redirects NAND to the flashcard SD card. This requires the following files and folders, obtained from a DSi nand dump, in the root of your flashcard SD card:
+When running DSiWare, Pico Loader redirects NAND to the flashcard SD card. This requires the following files and folders, obtained from a DSi nand dump or 3DS TWLNAND partition, in the `_pico` folder of your flashcard SD card (File names starting with **\*** indicate that they are optional and are used by a few system tools, such as `DSi System Settings`):
 - `photo` - The photo partition of nand will be redirected to this folder
-- `shared1`
-    - `TWLCFG0.dat`
-    - `TWLCFG1.dat`
-- `shared2`
-    - `launcher`
-        - `wrap.bin`
-- `sys`
-    - `log`
-        - `product.log`
-        - `shop.log`
-        - `sysmenu.log`
-    - `cert.sys`
-    - `dev.kp`
-    - `HWID.sgn`
-    - `HWINFO_N.dat`
-    - `HWINFO_S.dat`
-    - `TWLFontTable.dat`
+- `snd` - The sound files of nand will be redirected to this folder
+    - `0000` - The default sound file used by DSi Sound
+- `twln` - The standard region (aka worldwide) NAND folder
+    - `shared1`
+        - **\*** `TWLCFG0.dat`
+        - **\*** `TWLCFG1.dat`
+    - `shared2`
+        - `launcher`
+            - **\*** `wrap.bin`
+    - `sys`
+        - **\*** `cert.sys`
+        - **\*** `dev.kp`
+        - **\*** `HWID.sgn`
+        - **\*** `HWINFO_N.dat`
+        - **\*** `HWINFO_S.dat`
+        - `TWLFontTable.dat` - Normal Font (843.1KB)
+- `twlc` - The CHN region NAND folder (optional, only used by the CHN version of DSiWare)
+    - **•••**
+    - `sys`
+        - **•••**
+        - `TWLFontTable.dat` - CHN Font (568.1KB)
+- `twlk` - The KOR region NAND folder (optional, only used by the KOR version of DSiWare)
+    - **•••**
+    - `sys`
+        - **•••**
+        - `TWLFontTable.dat` - KOR Font (158.9KB)
 
 ## How to use Pico Loader from homebrew
 On the arm9:

--- a/arm7/source/loader/DsiWareSaveArranger.cpp
+++ b/arm7/source/loader/DsiWareSaveArranger.cpp
@@ -194,7 +194,7 @@ std::unique_ptr<DsiWareSaveArranger::fat_header_t> DsiWareSaveArranger::CreateFa
 bool DsiWareSaveArranger::CreateDeviceListPath(TCHAR* savePath, char* deviceListPath) const
 {
     auto fileInfo = std::make_unique<FILINFO>();
-    strcpy(deviceListPath, "nand:/");
+    strcpy(deviceListPath, "sdmc:/");
     char* shortPath = deviceListPath + 6;
     char* currentPathSegment = strchr(savePath, '/');
     do

--- a/arm7/source/loader/NdsLoader.cpp
+++ b/arm7/source/loader/NdsLoader.cpp
@@ -961,14 +961,31 @@ void NdsLoader::SetupDsiDeviceList()
     auto deviceList = (dsi_devicelist_t*)_romHeader.arm7DeviceListAddress;
     memset(deviceList, 0, sizeof(dsi_devicelist_t));
 
+    char romRegion = (_romHeader.gameCode >> 24) & 0xFF;
+    const char* nandPath = "sd:/_pico/twln";
+    const char* sharedPath = "sd:/_pico/twln/shared1";
+    if (romRegion == 'C')
+    {
+        nandPath = "sd:/_pico/twlc";
+        sharedPath = "sd:/_pico/twlc/shared1";
+    }
+    else if (romRegion == 'K')
+    {
+        nandPath = "sd:/_pico/twlk";
+        sharedPath = "sd:/_pico/twlk/shared1";
+    }
+
     int listEntry = 0;
-    SetDeviceListEntry(deviceList->deviceList[listEntry++], 'A', "nand", "/",
-        DSI_DEVICELIST_ENTRY_FLAGS_DRIVE_SDMC | DSI_DEVICELIST_ENTRY_FLAGS_TYPE_PHYSICAL,
-        DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_READ | DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_WRITE);
-    SetDeviceListEntry(deviceList->deviceList[listEntry++], 'D', "shared1", "nand:/shared1",
+    SetDeviceListEntry(deviceList->deviceList[listEntry++], 'A', "nand", nandPath,
         DSI_DEVICELIST_ENTRY_FLAGS_DRIVE_SDMC | DSI_DEVICELIST_ENTRY_FLAGS_TYPE_FOLDER,
         DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_READ | DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_WRITE);
-    SetDeviceListEntry(deviceList->deviceList[listEntry++], 'F', "photo", "nand:/photo",
+    SetDeviceListEntry(deviceList->deviceList[listEntry++], 'B', "sd", "/",
+        DSI_DEVICELIST_ENTRY_FLAGS_DRIVE_SDMC | DSI_DEVICELIST_ENTRY_FLAGS_TYPE_PHYSICAL,
+        DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_READ | DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_WRITE);
+    SetDeviceListEntry(deviceList->deviceList[listEntry++], 'D', "shared1", sharedPath,
+        DSI_DEVICELIST_ENTRY_FLAGS_DRIVE_SDMC | DSI_DEVICELIST_ENTRY_FLAGS_TYPE_FOLDER,
+        DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_READ | DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_WRITE);
+    SetDeviceListEntry(deviceList->deviceList[listEntry++], 'F', "photo", "sd:/_pico/photo",
         DSI_DEVICELIST_ENTRY_FLAGS_DRIVE_SDMC | DSI_DEVICELIST_ENTRY_FLAGS_TYPE_FOLDER,
         DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_READ | DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_WRITE);
 
@@ -986,7 +1003,7 @@ void NdsLoader::SetupDsiDeviceList()
             DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_READ | DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_WRITE);
     }
 
-    SetDeviceListEntry(deviceList->deviceList[listEntry++], 'I', "sdmc", "nand:/.",
+    SetDeviceListEntry(deviceList->deviceList[listEntry++], 'I', "sdmc", "sd:/.",
         DSI_DEVICELIST_ENTRY_FLAGS_DRIVE_SDMC | DSI_DEVICELIST_ENTRY_FLAGS_TYPE_FOLDER,
         DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_READ | DSI_DEVICELIST_ENTRY_ACCESS_RIGHTS_WRITE);
 

--- a/arm9/source/Arm7Patcher.cpp
+++ b/arm9/source/Arm7Patcher.cpp
@@ -15,6 +15,7 @@
 #include "patches/arm7/DisableArm7WramClearPatch.h"
 #include "patches/arm7/sdk5/Sdk5DsiSdCardRedirectPatch.h"
 #include "patches/arm7/PokemonDownloaderArm7Patch.h"
+#include "patches/arm7/RedirectSoundFolderArm7Patch.h"
 #include "Arm7Patcher.h"
 
 void* Arm7Patcher::ApplyPatches(const LoaderPlatform* loaderPlatform) const
@@ -59,6 +60,11 @@ void* Arm7Patcher::ApplyPatches(const LoaderPlatform* loaderPlatform) const
             if (gIsDsiMode && (twlRomHeader->HasNandAccess() || twlRomHeader->HasSdAccess()))
             {
                 patchCollection.AddPatch(new Sdk5DsiSdCardRedirectPatch());
+            }
+
+            if (gIsDsiMode && twlRomHeader->HasShared2Access())
+            {
+                patchCollection.AddPatch(new RedirectSoundFolderArm7Patch());
             }
 
             if (!twlRomHeader->IsDsiWare())

--- a/arm9/source/patches/arm7/RedirectSoundFolderArm7Patch.cpp
+++ b/arm9/source/patches/arm7/RedirectSoundFolderArm7Patch.cpp
@@ -1,0 +1,32 @@
+#include "common.h"
+#include "../PatchContext.h"
+#include "RedirectSoundFolderArm7Patch.h"
+
+static const u32 sSoundFolderPathTextPattern[] = { 0x646E616Eu, 0x68732F3Au, 0x64657261u, 0x30252F32u };
+
+bool RedirectSoundFolderArm7Patch::FindPatchTarget(PatchContext& patchContext)
+{
+    _shared2PathOffset = patchContext.FindPattern32Twl(sSoundFolderPathTextPattern, sizeof(sSoundFolderPathTextPattern));;
+
+    if (_shared2PathOffset)
+    {
+        LOG_DEBUG("Arm7i shared2 path offset found at 0x%p\n", _shared2PathOffset);
+    }
+    else
+    {
+        LOG_WARNING("Arm7i shared2 path offset not found\n");
+    }
+
+    return _shared2PathOffset != nullptr;
+}
+
+void RedirectSoundFolderArm7Patch::ApplyPatch(PatchContext& patchContext)
+{
+    if (!_shared2PathOffset)
+        return;
+
+    _shared2PathOffset[0] = 0x2F3A6473; // "sd:/"
+    _shared2PathOffset[1] = 0x6369705F; // "_pic"
+    _shared2PathOffset[2] = 0x6E732F6F; // "o/sn"
+    _shared2PathOffset[3] = 0x30252F64; // "d/%0"
+}

--- a/arm9/source/patches/arm7/RedirectSoundFolderArm7Patch.h
+++ b/arm9/source/patches/arm7/RedirectSoundFolderArm7Patch.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "../Patch.h"
+
+/// @brief Arm7 patch to redirecting sound folder to our sub directory.
+class RedirectSoundFolderArm7Patch : public Patch
+{
+public:
+    bool FindPatchTarget(PatchContext& patchContext) override;
+    void ApplyPatch(PatchContext& patchContext) override;
+
+private:
+    u32* _shared2PathOffset = nullptr;
+};


### PR DESCRIPTION
This PR close #36.
Multi nand support has been added. When booting a dsi rom with region CHN or KOR, the `_pico/_twlc` or `_pico/twlk` directory is used instead of the original `_pico/twln` directory.
This allows different region TWL font files to be used on a single device without requiring any patches to Virtual Filename Placeholders `<sharedFont>`. And also allows issue #32 to be closed.

Tested and works fine on: DSPico v1.3 + Firmware v1.0