### PR TITLE
Ignore ROM reads into null pointer destinations

### DIFF
--- a/arm9/source/patches/arm9/sdk2to4/CardiReadCardPatchAsm.s
+++ b/arm9/source/patches/arm9/sdk2to4/CardiReadCardPatchAsm.s
@@ -57,8 +57,13 @@ patch_cardireadcard_mov_r3_to_dst:
     str r3, [r6, #0x24]
 
 do_read:
+    lsrs r3, r1, #24 // if dst address is invalid (close to zero), ignore the read
+    beq ignore_read  // this is intended to fix reads to null pointers that would be ignored if done with DMA
+
     ldr r3, __patch_cardireadcard_sdread_asm_address
     blx r3
+
+ignore_read:
     pop {r1,r2,r3,r4,r6,pc}
 
 .balign 4

--- a/arm9/source/patches/arm9/sdk5/CardiReadRomWithCpuPatchAsm.s
+++ b/arm9/source/patches/arm9/sdk5/CardiReadRomWithCpuPatchAsm.s
@@ -43,6 +43,9 @@ patch_cardireadromwithcpu_mov_left_to_read_to_r2:
     lsls r7, r2, #9
 
 do_read:
+    lsrs r3, r1, #24 // if dst address is invalid (close to zero), ignore the read
+    beq ignore_read  // this is intended to fix reads to null pointers that would be ignored if done with DMA
+
     ldr r3, __patch_cardireadromwithcpu_sdread_asm_address
     blx r3
     // arm
@@ -53,6 +56,8 @@ do_read:
     // r7 = number of bytes read
     // r5 = number of bytes left to read
     // [sp + 0 + 4] = actual dst
+
+ignore_read:
     pop {pc}
 
 .balign 4


### PR DESCRIPTION
DMA ROM reads ignore null pointer destinations, but if they are coerced to CPU reads they will data abort. If the destination address is under `01000000` it will be considered invalid.

Fixes #121 