### PR TITLE
dstt: split read SD patch to reduce patch code space

### DIFF
--- a/arm9/source/patches/platform/dstt/DsttLoaderPlatform.cpp
+++ b/arm9/source/patches/platform/dstt/DsttLoaderPlatform.cpp
@@ -190,7 +190,7 @@ bool DsttLoaderPlatform::InitializeSdCard(void)
     if (isSdhc)
     {
         sdHostSetRegister(DSTT_SD_HOST_REG_RESET | DSTT_SD_HOST_REG_CLEAN_ROM_MODE | DSTT_SD_HOST_REG_SDHC);
-        dstt_readSd_sdsc_shift = THUMB_MOVS_REG(THUMB_R7, THUMB_R0);
+        dstt_readSd_sdsc_shift = THUMB_MOVS_REG(THUMB_R6, THUMB_R0);
         dstt_writeSd_sdsc_shift = THUMB_NOP;
     }
     return true;

--- a/arm9/source/patches/platform/dstt/DsttLoaderPlatform.h
+++ b/arm9/source/patches/platform/dstt/DsttLoaderPlatform.h
@@ -2,6 +2,10 @@
 #include "../LoaderPlatform.h"
 #include "DsttReadSdPatchCode.h"
 #include "DsttWriteSdPatchCode.h"
+#include "DsttSdStopTransmissionPatchCode.h"
+#include "DsttReadSdApplySectorCommandPatchCode.h"
+#include "DsttReadSdWaitDataReadyPatchCode.h"
+#include "DsttReadSdTransferDataPatchCode.h"
 
 /// @brief Implementation of LoaderPlatform for the DSTT flashcard
 class DsttLoaderPlatform : public LoaderPlatform
@@ -15,7 +19,19 @@ public:
             return new DsttReadSdPatchCode(patchHeap,
                 patchCodeCollection.GetOrAddSharedPatchCode([&]
                 {
-                    return new DsttReadSdStopTransmissionPatchCode(patchHeap);
+                    return new DsttSdStopTransmissionPatchCode(patchHeap);
+                }),
+                patchCodeCollection.GetOrAddSharedPatchCode([&]
+                {
+                    return new DsttReadSdApplySectorCommandPatchCode(patchHeap);
+                }),
+                patchCodeCollection.GetOrAddSharedPatchCode([&]
+                {
+                    return new DsttReadSdWaitDataReadyPatchCode(patchHeap);
+                }),
+                patchCodeCollection.GetOrAddSharedPatchCode([&]
+                {
+                    return new DsttReadSdTransferDataPatchCode(patchHeap);
                 }));
         });
     }

--- a/arm9/source/patches/platform/dstt/DsttReadSdApplySectorCommandPatchCode.h
+++ b/arm9/source/patches/platform/dstt/DsttReadSdApplySectorCommandPatchCode.h
@@ -1,0 +1,22 @@
+#pragma once
+#include "sections.h"
+#include "thumbInstructions.h"
+#include "patches/PatchCode.h"
+
+DEFINE_SECTION_SYMBOLS(dstt_readsd_applysectorcommand);
+
+extern "C" void dstt_readSd_applySectorCommand();
+
+extern u16 dstt_readSd_sdsc_shift;
+
+class DsttReadSdApplySectorCommandPatchCode : public PatchCode
+{
+public:
+    explicit DsttReadSdApplySectorCommandPatchCode(PatchHeap& patchHeap)
+        : PatchCode(SECTION_START(dstt_readsd_applysectorcommand), SECTION_SIZE(dstt_readsd_applysectorcommand), patchHeap) { }
+
+    const void* GetApplySectorCommandFunction() const
+    {
+        return GetAddressAtTarget((void*)dstt_readSd_applySectorCommand);
+    }
+};

--- a/arm9/source/patches/platform/dstt/DsttReadSdApplySectorCommandPatchCode.s
+++ b/arm9/source/patches/platform/dstt/DsttReadSdApplySectorCommandPatchCode.s
@@ -1,0 +1,39 @@
+.cpu arm7tdmi
+.section "dstt_readsd_applysectorcommand", "ax"
+.syntax unified
+.thumb
+
+// r0 = src sector
+.global dstt_readSd_applySectorCommand
+.type dstt_readSd_applySectorCommand, %function
+dstt_readSd_applySectorCommand:
+    push {r4-r6,lr}
+
+.global dstt_readSd_sdsc_shift
+dstt_readSd_sdsc_shift:
+    lsls r6, r0, #9
+
+    ldr r4, =0x040001A0
+
+    // request sd read for sector 0xaabbccdd
+    // 54 aa bb cc dd 00 00 00
+    movs r5, #0x54
+    strb r5, [r4,#0x8]
+    lsrs r5, r6, #24
+    strb r5, [r4,#0x9]
+    lsrs r5, r6, #16
+    strb r5, [r4,#0xA]
+    lsrs r5, r6, #8
+    strb r5, [r4,#0xB]
+    // make sure the last 3 bytes are zero
+    movs r5, #0xFF
+    ands r6, r5
+    str r6, [r4,#0xC] // storing as little-endian puts the bottom 8 bits as first byte
+
+    pop {r4-r6,pc}
+
+.balign 4
+
+.pool
+
+.end

--- a/arm9/source/patches/platform/dstt/DsttReadSdPatchCode.h
+++ b/arm9/source/patches/platform/dstt/DsttReadSdPatchCode.h
@@ -3,36 +3,34 @@
 #include "thumbInstructions.h"
 #include "patches/PatchCode.h"
 #include "../IReadSectorsPatchCode.h"
+#include "DsttSdStopTransmissionPatchCode.h"
+#include "DsttReadSdApplySectorCommandPatchCode.h"
+#include "DsttReadSdWaitDataReadyPatchCode.h"
+#include "DsttReadSdTransferDataPatchCode.h"
 
 DEFINE_SECTION_SYMBOLS(dstt_readsd);
-DEFINE_SECTION_SYMBOLS(dstt_readsd_stopTransmission);
 
 extern "C" void dstt_readSd(u32 srcSector, void* dst, u32 sectorCount);
-extern "C" void dstt_stopTransmission();
 
+extern u32 dstt_readSd_applySectorCommand_address;
+extern u32 dstt_waitDataReady_address;
+extern u32 dstt_transferData_address;
 extern u32 dstt_stopTransmission_address;
-extern u16 dstt_readSd_sdsc_shift;
-
-class DsttReadSdStopTransmissionPatchCode : public PatchCode
-{
-public:
-    explicit DsttReadSdStopTransmissionPatchCode(PatchHeap& patchHeap)
-        : PatchCode(SECTION_START(dstt_readsd_stopTransmission), SECTION_SIZE(dstt_readsd_stopTransmission), patchHeap) { }
-
-    const void* GetStopTransmissionFunction() const
-    {
-        return GetAddressAtTarget((void*)dstt_stopTransmission);
-    }
-};
 
 class DsttReadSdPatchCode : public PatchCode, public IReadSectorsPatchCode
 {
 public:
     explicit DsttReadSdPatchCode(PatchHeap& patchHeap,
-        const DsttReadSdStopTransmissionPatchCode* dsttReadSdStopTransmissionPatchCode)
+        const DsttSdStopTransmissionPatchCode* dsttSdStopTransmissionPatchCode,
+        const DsttReadSdApplySectorCommandPatchCode* dsttReadSdApplySectorCommandPatchCode,
+        const DsttReadSdWaitDataReadyPatchCode* dsttReadSdWaitDataReadyPatchCode,
+        const DsttReadSdTransferDataPatchCode* dsttReadSdTransferDataPatchCode)
         : PatchCode(SECTION_START(dstt_readsd), SECTION_SIZE(dstt_readsd), patchHeap)
         {
-            dstt_stopTransmission_address = (u32)dsttReadSdStopTransmissionPatchCode->GetStopTransmissionFunction();
+            dstt_readSd_applySectorCommand_address = (u32)dsttReadSdApplySectorCommandPatchCode->GetApplySectorCommandFunction();
+            dstt_stopTransmission_address = (u32)dsttSdStopTransmissionPatchCode->GetStopTransmissionFunction();
+            dstt_waitDataReady_address = (u32)dsttReadSdWaitDataReadyPatchCode->GetWaitDataReadyFunction();
+            dstt_transferData_address = (u32)dsttReadSdTransferDataPatchCode->GetTransferDataFunction();
         }
 
     const ReadSectorsFunc GetReadSectorsFunction() const override

--- a/arm9/source/patches/platform/dstt/DsttReadSdPatchCode.s
+++ b/arm9/source/patches/platform/dstt/DsttReadSdPatchCode.s
@@ -11,27 +11,11 @@
 dstt_readSd:
     push {r4-r7,lr}
 
-.global dstt_readSd_sdsc_shift
-dstt_readSd_sdsc_shift:
-    lsls r7, r0, #9
+    ldr r7, dstt_readSd_applySectorCommand_address
+    bl blx_r7
 
-    adr r0, dstt_stopTransmission_address
-    ldmia r0, {r0, r3, r4}
-
-    // request sd read for sector 0xaabbccdd
-    // 54 aa bb cc dd 00 00 00
-    movs r5, #0x54
-    strb r5, [r4,#0x8]
-    lsrs r5, r7, #24
-    strb r5, [r4,#0x9]
-    lsrs r5, r7, #16
-    strb r5, [r4,#0xA]
-    lsrs r5, r7, #8
-    strb r5, [r4,#0xB]
-    // make sure the last 3 bytes are zero
-    movs r5, #0xFF
-    ands r7, r5
-    str r7, [r4,#0xC] // storing as little-endian puts the bottom 8 bits as first byte
+    ldr r3, =0xA7180000
+    ldr r4, =0x040001A0
 
     movs r7, #0x80
     strb r7, [r4,#1]
@@ -48,42 +32,11 @@ cmd54_wait_loop:
     bcc cmd54_wait_loop
 
     ldr r5, [r6, #0x10]
-    // sd fifo full poll
-    // 80 xx xx xx xx xx xx xx
-    // xx bytes are leftover from previous command
-    strb r7, [r4,#0x8]
+    ldr r7, dstt_waitDataReady_address
+    bl blx_r7
 
-cmd80_poll_loop:
-    str r3, [r4,#4]
-
-cmd80_wait_loop:
-    ldrb r5, [r4,#6]
-    lsrs r5, r5, #8
-    bcc cmd80_wait_loop
-    ldr r5, [r6, #0x10]
-    cmp r5, #0
-    bne cmd80_poll_loop
-
-    // read sd fifo
-    // 81 xx xx xx xx xx xx xx
-    // xx bytes are leftover from previous command
-    movs r5, #0x81
-    strb r5, [r4,#0x8]
-    movs r5, #0xA1
-    strb r5, [r4,#7]
-
-cmd81_data_loop:
-    ldrb r5, [r4,#6]
-    lsrs r5, r5, #8 // check if data is ready
-    bcc cmd81_data_loop_check_transfer_end // if not skip reading
-
-    ldr r5, [r6, #0x10]
-    stmia r1!, {r5}
-
-cmd81_data_loop_check_transfer_end:
-    ldrb r5, [r4,#7]
-    lsrs r5, r5, #8 // check if transfer is done
-    bcs cmd81_data_loop
+    ldr r7, dstt_transferData_address
+    bl blx_r7
 
     subs r2, #1
     beq stop_transmission
@@ -99,76 +52,30 @@ cmd81_data_loop_check_transfer_end:
     b sector_loop
 
 stop_transmission:
-    bx r0
+    ldr r7, dstt_stopTransmission_address
+    bl blx_r7
+    pop {r4-r7,pc}
+
+blx_r7:
+    bx r7
 
 .balign 4
+
+.global dstt_readSd_applySectorCommand_address
+dstt_readSd_applySectorCommand_address:
+    .word 0
+
+.global dstt_waitDataReady_address
+dstt_waitDataReady_address:
+    .word 0
+
+.global dstt_transferData_address
+dstt_transferData_address:
+    .word 0
 
 .global dstt_stopTransmission_address
 dstt_stopTransmission_address:
     .word 0
-
-settings:
-    .word 0xA7180000
-
-regbase:
-    .word 0x040001A0
-
-.pool
-
-.section "dstt_readsd_stopTransmission", "ax"
-.thumb
-.global dstt_stopTransmission
-.type dstt_stopTransmission, %function
-dstt_stopTransmission:
-    // send SD_CMD12_STOP_TRANSMISSION
-
-    // set sd host mode DSTT_MODE_SDCMD_RESPONSE_32BIT, SD_CMD12_STOP_TRANSMISSION
-    // 51 00 00 00 00 0C 01 00
-    movs r5, #0x51
-    str r5, [r4,#0x8]
-    ldr r5,= 0x00010C00
-    str r5, [r4,#0xC]
-    str r3, [r4,#4]
-
-cmd51_1_wait_loop:
-    ldrb r5, [r4,#6]
-    lsrs r5, r5, #8
-    bcc cmd51_1_wait_loop
-    ldr r5, [r6, #0x10]
-
-    // sd busy poll
-    // 50 xx xx xx xx xx xx xx
-    // xx bytes are leftover from previous command
-    movs r5, #0x50
-    strb r5, [r4,#0x8]
-
-cmd50_poll_loop:
-    str r3, [r4,#4]
-
-cmd50_wait_loop:
-    ldrb r5, [r4,#6]
-    lsrs r5, r5, #8
-    bcc cmd50_wait_loop
-    ldr r5, [r6, #0x10]
-    cmp r5, #0
-    bne cmd50_poll_loop
-
-    // read sd response
-    // 52 xx xx xx xx xx xx xx
-    // xx bytes are leftover from previous command
-    movs r5, #0x52
-    strb r5, [r4,#0x8]
-    str r3, [r4,#4]
-
-cmd52_wait_loop:
-    ldrb r5, [r4,#6]
-    lsrs r5, r5, #8
-    bcc cmd52_wait_loop
-    ldr r5, [r6, #0x10]
-
-    pop {r4-r7,pc}
-
-.balign 4
 
 .pool
 

--- a/arm9/source/patches/platform/dstt/DsttReadSdTransferDataPatchCode.h
+++ b/arm9/source/patches/platform/dstt/DsttReadSdTransferDataPatchCode.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "sections.h"
+#include "thumbInstructions.h"
+#include "patches/PatchCode.h"
+
+DEFINE_SECTION_SYMBOLS(dstt_readsd_transferdata);
+
+extern "C" void dstt_readSd_transferData();
+
+class DsttReadSdTransferDataPatchCode : public PatchCode
+{
+public:
+    explicit DsttReadSdTransferDataPatchCode(PatchHeap& patchHeap)
+        : PatchCode(SECTION_START(dstt_readsd_transferdata), SECTION_SIZE(dstt_readsd_transferdata), patchHeap) { }
+
+    const void* GetTransferDataFunction() const
+    {
+        return GetAddressAtTarget((void*)dstt_readSd_transferData);
+    }
+};

--- a/arm9/source/patches/platform/dstt/DsttReadSdTransferDataPatchCode.s
+++ b/arm9/source/patches/platform/dstt/DsttReadSdTransferDataPatchCode.s
@@ -1,0 +1,47 @@
+.cpu arm7tdmi
+.section "dstt_readsd_transferdata", "ax"
+.syntax unified
+.thumb
+
+// r0 = src sector
+// r1 = dst
+// r2 = sector count
+.global dstt_readSd_transferData
+.type dstt_readSd_transferData, %function
+dstt_readSd_transferData:
+    push {r4-r7,lr}
+
+    ldr r4, =0x040001A0
+    ldr r5, =0xA7180000
+
+    movs r6, #0x41
+    lsls r6, r6, #20
+
+    // read sd fifo
+    // 81 xx xx xx xx xx xx xx
+    // xx bytes are leftover from previous command
+    movs r5, #0x81
+    strb r5, [r4,#0x8]
+    movs r5, #0xA1
+    strb r5, [r4,#7]
+
+cmd81_data_loop:
+    ldrb r5, [r4,#6]
+    lsrs r5, r5, #8 // check if data is ready
+    bcc cmd81_data_loop_check_transfer_end // if not skip reading
+
+    ldr r5, [r6, #0x10]
+    stmia r1!, {r5}
+
+cmd81_data_loop_check_transfer_end:
+    ldrb r5, [r4,#7]
+    lsrs r5, r5, #8 // check if transfer is done
+    bcs cmd81_data_loop
+
+    pop {r4-r7,pc}
+
+.balign 4
+
+.pool
+
+.end

--- a/arm9/source/patches/platform/dstt/DsttReadSdWaitDataReadyPatchCode.h
+++ b/arm9/source/patches/platform/dstt/DsttReadSdWaitDataReadyPatchCode.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "sections.h"
+#include "thumbInstructions.h"
+#include "patches/PatchCode.h"
+
+DEFINE_SECTION_SYMBOLS(dstt_readsd_waitdataready);
+
+extern "C" void dstt_readSd_waitDataReady();
+
+class DsttReadSdWaitDataReadyPatchCode : public PatchCode
+{
+public:
+    explicit DsttReadSdWaitDataReadyPatchCode(PatchHeap& patchHeap)
+        : PatchCode(SECTION_START(dstt_readsd_waitdataready), SECTION_SIZE(dstt_readsd_waitdataready), patchHeap) { }
+
+    const void* GetWaitDataReadyFunction() const
+    {
+        return GetAddressAtTarget((void*)dstt_readSd_waitDataReady);
+    }
+};

--- a/arm9/source/patches/platform/dstt/DsttReadSdWaitDataReadyPatchCode.s
+++ b/arm9/source/patches/platform/dstt/DsttReadSdWaitDataReadyPatchCode.s
@@ -1,0 +1,44 @@
+.cpu arm7tdmi
+.section "dstt_readsd_waitdataready", "ax"
+.syntax unified
+.thumb
+
+// r0 = src sector
+// r1 = dst
+// r2 = sector count
+.global dstt_readSd_waitDataReady
+.type dstt_readSd_waitDataReady, %function
+dstt_readSd_waitDataReady:
+    push {r4-r7,lr}
+
+    ldr r4, =0x040001A0
+    ldr r5, =0xA7180000
+
+    movs r6, #0x41
+    lsls r6, r6, #20
+
+    // sd fifo full poll
+    // 80 xx xx xx xx xx xx xx
+    // xx bytes are leftover from previous command
+    movs r7, #0x80
+    strb r7, [r4,#0x8]
+
+    ldr r7, =0xA7180000
+cmd80_poll_loop:
+    str r7, [r4,#4]
+
+cmd80_wait_loop:
+    ldrb r5, [r4,#6]
+    lsrs r5, r5, #8
+    bcc cmd80_wait_loop
+    ldr r5, [r6, #0x10]
+    cmp r5, #0
+    bne cmd80_poll_loop
+
+    pop {r4-r7,pc}
+
+.balign 4
+
+.pool
+
+.end

--- a/arm9/source/patches/platform/dstt/DsttSdStopTransmissionPatchCode.h
+++ b/arm9/source/patches/platform/dstt/DsttSdStopTransmissionPatchCode.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "sections.h"
+#include "thumbInstructions.h"
+#include "patches/PatchCode.h"
+
+DEFINE_SECTION_SYMBOLS(dstt_sdstoptransmission);
+
+extern "C" void dstt_sdStopTransmission();
+
+class DsttSdStopTransmissionPatchCode : public PatchCode
+{
+public:
+    explicit DsttSdStopTransmissionPatchCode(PatchHeap& patchHeap)
+        : PatchCode(SECTION_START(dstt_sdstoptransmission), SECTION_SIZE(dstt_sdstoptransmission), patchHeap) { }
+
+    const void* GetStopTransmissionFunction() const
+    {
+        return GetAddressAtTarget((void*)dstt_sdStopTransmission);
+    }
+};

--- a/arm9/source/patches/platform/dstt/DsttSdStopTransmissionPatchCode.s
+++ b/arm9/source/patches/platform/dstt/DsttSdStopTransmissionPatchCode.s
@@ -1,0 +1,68 @@
+.cpu arm7tdmi
+.syntax unified
+.thumb
+
+.section "dstt_sdstoptransmission", "ax"
+.global dstt_sdStopTransmission
+.type dstt_sdStopTransmission, %function
+dstt_sdStopTransmission:
+    // send SD_CMD12_STOP_TRANSMISSION
+    push {r4-r6,lr}
+
+    ldr r3, =0xA7180000
+    ldr r4, =0x040001A0
+
+    // set sd host mode DSTT_MODE_SDCMD_RESPONSE_32BIT, SD_CMD12_STOP_TRANSMISSION
+    // 51 00 00 00 00 0C 01 00
+    movs r5, #0x51
+    str r5, [r4,#0x8]
+    ldr r5,= 0x00010C00
+    str r5, [r4,#0xC]
+    str r3, [r4,#0x4]
+
+    movs r6, #0x41
+    lsls r6, r6, #20
+
+cmd51_1_wait_loop:
+    ldrb r5, [r4,#6]
+    lsrs r5, r5, #8
+    bcc cmd51_1_wait_loop
+    ldr r5, [r6, #0x10]
+
+    // sd busy poll
+    // 50 xx xx xx xx xx xx xx
+    // xx bytes are leftover from previous command
+    movs r5, #0x50
+    strb r5, [r4,#0x8]
+
+cmd50_poll_loop:
+    str r3, [r4,#4]
+
+cmd50_wait_loop:
+    ldrb r5, [r4,#6]
+    lsrs r5, r5, #8
+    bcc cmd50_wait_loop
+    ldr r5, [r6, #0x10]
+    cmp r5, #0
+    bne cmd50_poll_loop
+
+    // read sd response
+    // 52 xx xx xx xx xx xx xx
+    // xx bytes are leftover from previous command
+    movs r5, #0x52
+    strb r5, [r4,#0x8]
+    str r3, [r4,#4]
+
+cmd52_wait_loop:
+    ldrb r5, [r4,#6]
+    lsrs r5, r5, #8
+    bcc cmd52_wait_loop
+    ldr r5, [r6, #0x10]
+
+    pop {r4-r6,pc}
+
+.balign 4
+
+.pool
+
+.end


### PR DESCRIPTION
Previously the main patch (prior to CMD12) was 0x78 bytes, which caused some games to fail to load.

It has been split into 4 sections:
- IReadSectorsPatchCode entrypoint
- Apply 0x54 command
- Wait for data ready loop
- Transfer data loop

Additionally, the CMD12 command has been split into its own file, in order to reuse this patch code in the future.

Fixes most games from #111, which has a few games not working in the list due to a lack of a DMA implementation.