### PR TITLE
workflow: bump all dependencies

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,7 +34,7 @@ jobs:
           "MPCF"
         ]
     runs-on: ubuntu-latest
-    container: skylyrac/blocksds:slim-v1.13.1
+    container: skylyrac/blocksds:slim-v1.20.0
     name: Build Pico Loader
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
@@ -43,10 +43,10 @@ jobs:
       DOTNET_NOLOGO: true
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 9.x
       - name: Run build script
@@ -58,7 +58,7 @@ jobs:
           mv picoLoader7.bin data/aplist.bin data/patchlist.bin data/savelist.bin Pico_Loader_${{ matrix.platform }}
           mv picoLoader9_${{ matrix.platform }}.bin Pico_Loader_${{ matrix.platform }}/picoLoader9.bin
       - name: Publish build to GH Actions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           path: |
             Pico_Loader_${{ matrix.platform }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           "MPCF"
         ]
     runs-on: ubuntu-latest
-    container: skylyrac/blocksds:slim-v1.13.1
+    container: skylyrac/blocksds:slim-v1.20.0
     name: Build Pico Loader
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
@@ -37,10 +37,10 @@ jobs:
       DOTNET_NOLOGO: true
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 9.x
       - name: Install zip
@@ -55,7 +55,7 @@ jobs:
           mv picoLoader7.bin data/aplist.bin data/patchlist.bin data/savelist.bin Pico_Loader_${{ matrix.platform }}
           mv picoLoader9_${{ matrix.platform }}.bin Pico_Loader_${{ matrix.platform }}/picoLoader9.bin
       - name: Publish build to GH Actions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           path: |
             Pico_Loader_${{ matrix.platform }}
@@ -65,7 +65,7 @@ jobs:
         run: |
           cd Pico_Loader_${{ matrix.platform }} && zip -r $PWD.zip *
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             Pico_Loader_${{ matrix.platform }}.zip


### PR DESCRIPTION
- BlocksDS -> v1.20.0
- actions/upload-artifact -> v7
- actions/checkout -> v6
- actions/setup-dotnet -> v5
- softprops/action-gh-release -> v3