### PR TITLE
Add AP patch for NRL Mascot Mania and AFL Mascot Manor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - DMA card read support for the DSTT platform - by @lifehackerhansol
 - DMA card read support for the M3DS platform - by @lifehackerhansol
+- AP patches for NRL Mascot Mania and AFL Mascot Manor - by @taxicat1
 
 ### Fixed
 - DMA card read offsets for Pokemon Ranger (EU) - by @taxicat1

--- a/data/patchlist.json
+++ b/data/patchlist.json
@@ -231,6 +231,45 @@
         ]
     },
 
+    // CQKP - NRL Mascot Mania (Europe)
+    // CQQP - AFL Mascot Manor (Europe)
+    //
+    // These games have EEPROM-probing AP that is nearly identical to the Dementium II AP above, except the function is
+    // not inlined and so can be stubbed over to return the correct value.
+    // Additionally, they have a function to do a CRC check on the ARM7. This is patched by adding a jump directly to a successful return.
+    {
+        "gameCode": "CQKP", // NRL Mascot Mania (Europe)
+        "gameVersion": 0,
+        "patches": [
+            {
+                "type": "replace",
+                "address": "0206FC10",
+                "data": "0D 00 00 EA"
+            },
+            {
+                "type": "replace",
+                "address": "0206FF70",
+                "data": "01 00 A0 E3 1E FF 2F E1"
+            }
+        ]
+    },
+    {
+        "gameCode": "CQQP", // AFL Mascot Manor (Europe)
+        "gameVersion": 0,
+        "patches": [
+            {
+                "type": "replace",
+                "address": "0206EB88",
+                "data": "0D 00 00 EA"
+            },
+            {
+                "type": "replace",
+                "address": "0206EEE8",
+                "data": "01 00 A0 E3 1E FF 2F E1"
+            }
+        ]
+    },
+
     // YGXE - Grand Theft Auto - Chinatown Wars (USA)
     // YGXP - Grand Theft Auto - Chinatown Wars (Europe)
     // YGXJ - Grand Theft Auto - Chinatown Wars (Japan)


### PR DESCRIPTION
These games have two kinds of AP:
- Sending manual EEPROM commands (identically to Dementium II): https://decomp.me/scratch/bT0LR
- Checking a CRC of the ARM7: https://decomp.me/scratch/bNzTG

The functions are exactly the same in both games. If they fail it will not let you save and will kick you back out to the menu after level 3.

Wood Kernel has this patch: https://github.com/ahezard/wood3ds/blob/master/akloader/arm9/source/patches_cm.cpp#L1006

The EEPROM command test patch is unchanged. I have changed the ARM7 CRC patch to write to the function `8: b 44`