### PR TITLE
workflow: drop actions/checkout to v4

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,7 +43,7 @@ jobs:
       DOTNET_NOLOGO: true
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           submodules: true
       - uses: actions/setup-dotnet@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       DOTNET_NOLOGO: true
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           submodules: true
       - uses: actions/setup-dotnet@v5


### PR DESCRIPTION
There is a known regression upstream that causes authenticating repos to die (even though the repo doesn't even need authentication): https://github.com/actions/checkout/issues/2393

Drop down to v4 which doesn't have this issue.