### PR TITLE
Fix DSi mode booting for homebrew applications

### DIFF
--- a/arm7/source/loader/NdsLoader.cpp
+++ b/arm7/source/loader/NdsLoader.cpp
@@ -176,6 +176,10 @@ void NdsLoader::Load(BootMode bootMode)
     if (isHomebrew)
     {
         LOG_DEBUG("Homebrew\n");
+        sendToArm9(IPC_COMMAND_ARM9_SET_ROM_FILE_INFO);
+        sendToArm9(_romFile.dir_sect);
+        sendToArm9((u32)(_romFile.dir_ptr - _romFile.obj.fs->win));
+        sendToArm9(_runInDSiMode ? 2 : 0);
     }
     else
     {


### PR DESCRIPTION
Fixes a data abort crash (Guru Meditation Error) when launching DSi-enhanced homebrew like GodMode9i on DSi by properly sending the ROM file info and DSi flags to the ARM9