### PR TITLE
Pokémon Dash under Pico Loader — progress report / Bilan

### DIFF
--- a/arm9/source/patches/arm9/sdk2to4/CardiReadCardPatch.cpp
+++ b/arm9/source/patches/arm9/sdk2to4/CardiReadCardPatch.cpp
@@ -9,6 +9,7 @@
 #include "gameCode.h"
 #include "CardiReadCardPatchAsm.h"
 #include "CardiReadCardPatch.h"
+#include "DashCmdPatchCode.h"
 
 static const u32 sCARDiReadCardPatternUnknown[] = { 0xE92D4FF0u, 0xE24DD004u, 0xE1A0A000u, 0xE59F90D8u };
 static const u32 sCARDiReadCardPatternSdk20029A7[] = { 0xE92D4FF0u, 0xE24DD004u, 0xE1A0A000u, 0xE59F90E0u };
@@ -146,6 +147,18 @@ void CardiReadCardPatch::ApplyPatch(PatchContext& patchContext)
         });
         __patch_cardireadcard_rom_offset_to_sd_sector_asm_address = (u32)romOffsetToSdSectorPatchCode->GetRemapFunction();
         __patch_cardireadcard_sdread_asm_address = (u32)sdReadPatchCode->GetReadSectorsFunction();
+    }
+    // v19 (Pokemon Dash) : la lecture SD par DMA vit dans sa propre section ;
+    // on l'alloue ici, tot, la ou le tas est peu fragmente (comme les autres
+    // patch codes), et non au site d'accroche Dash ou le plus grand bloc libre
+    // est reduit. dashReadDmaFn = adresse relogee de dash_readSdDma.
+    u32 dashReadDmaFn = 0;
+    if ((patchContext.GetGameCode() & 0x00FFFFFF) == GAMECODE_NO_REGION("APD"))
+    {
+        u32 dmaSize = SECTION_SIZE(dash_readsddma);
+        void* dmaAddr = patchContext.GetPatchHeap().Alloc(dmaSize);
+        memcpy(dmaAddr, SECTION_START(dash_readsddma), dmaSize);
+        dashReadDmaFn = (u32)&dash_readSdDma - (u32)SECTION_START(dash_readsddma) + (u32)dmaAddr;
     }
     u32 patch4Size = SECTION_SIZE(fixcp15);
     void* patch4Address = patchContext.GetPatchHeap().Alloc(patch4Size);
@@ -293,4 +306,35 @@ void CardiReadCardPatch::ApplyPatch(PatchContext& patchContext)
 
     memcpy(patch1Address, SECTION_START(patch_cardireadcard), patch1Size);
     memcpy(patch4Address, SECTION_START(fixcp15), patch4Size);
+
+    // Pokemon Dash (APD*) : le jeu lit son systeme de fichiers via un moteur
+    // DMA carte qui lui est propre, hors des fonctions CARDi_* redirigees vers
+    // la SD. On intercepte l'assemblage de la commande carte 0xB7 a 0x0206D3A4
+    // pour y substituer une lecture SD, dans le contexte d'execution de Dash.
+    // v19 : la lecture est par DMA (dashReadDmaFn) et non plus une copie
+    // processeur, afin de regenerer l'IRQ carte attendue par le moteur.
+    // dashReadDmaFn == 0 => l'alloc precoce a echoue : on n'accroche pas, Dash
+    // demarre comme non-patche (temoin d'echec lisible, pas de blx 0).
+    if (dashReadDmaFn != 0u
+        && (patchContext.GetGameCode() & 0x00FFFFFF) == GAMECODE_NO_REGION("APD"))
+    {
+        u32 dashSize = SECTION_SIZE(dash_cmd_fix);
+        void* dashAddr = patchContext.GetPatchHeap().Alloc(dashSize);
+        dbr_fixcp15    = __patch_cardireadcard_fix_cp15_asm_address;
+        dbr_remap      = __patch_cardireadcard_rom_offset_to_sd_sector_asm_address;
+        dbr_sdread     = dashReadDmaFn;
+        dbr_global_ptr = *(u32*)0x0206D470u;   // = 0x020D6144, contexte du moteur
+        memcpy(dashAddr, SECTION_START(dash_cmd_fix), dashSize);
+
+        u32 trampolineEntry = (u32)&dash_cmd_patch_entry
+                              - (u32)SECTION_START(dash_cmd_fix) + (u32)dashAddr;
+
+        volatile u32* ii = (volatile u32*)0x0206D3A4u;
+        // ii[0] : lsr r1, r5, #8  -> inchange (r5 = offset ROM du secteur)
+        ii[1] = 0xE1A00005u;   // mov r0, r5   : passe l'offset au trampoline
+        u32 blOffset = ((trampolineEntry - ((u32)&ii[2] + 8u)) >> 2) & 0x00FFFFFFu;
+        ii[2] = 0xEB000000u | blOffset;
+        ii[3] = 0xE28FF058u;   // add pc, pc, #0x58 -> ii+27
+        ii[28] = 0xE1A00000u;  // nop : supprime le dernier octet de commande
+    }
 }

--- a/arm9/source/patches/arm9/sdk2to4/DashCmdPatchCode.h
+++ b/arm9/source/patches/arm9/sdk2to4/DashCmdPatchCode.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "common.h"
+#include "sections.h"
+
+DEFINE_SECTION_SYMBOLS(dash_cmd_fix);
+DEFINE_SECTION_SYMBOLS(dash_readsddma);
+
+extern "C" void dash_cmd_patch_entry();
+extern "C" void dash_readSdDma(u32 srcSector, void* dst, u32 count);
+extern "C" u32 dbr_fixcp15;
+extern "C" u32 dbr_remap;
+extern "C" u32 dbr_global_ptr;
+extern "C" u32 dbr_sdread;

--- a/arm9/source/patches/arm9/sdk2to4/DashCmdPatchCode.s
+++ b/arm9/source/patches/arm9/sdk2to4/DashCmdPatchCode.s
@@ -1,0 +1,106 @@
+.cpu arm946e-s
+.section "dash_cmd_fix", "ax"
+.syntax unified
+.arm
+
+// Pokemon Dash (APDP) - lecture carte redirigee vers la SD.
+//
+// Point d'accroche : 0x0206D3A4, la ou le moteur propre a Dash assemble la
+// commande carte 0xB7. On y substitue une lecture SD, dans le contexte
+// d'execution de Dash lui-meme.
+//
+//   ctx   = [dbr_global_ptr]        (0x020D6144 = valeur du pool 0x0206D470)
+//   dst   = [ctx+0x30] - 0x200      (destination du secteur courant)
+//   count = [ctx+0x34] + 1          (secteurs restants + le courant)
+//
+// Zero pile : la pile IRQ de Dash est trop petite pour un push, lr est
+// sauvegarde dans la section elle-meme. Offsets de pool calcules par
+// l'assembleur via des etiquettes symboliques.
+//
+// v19 : identique a v11e, sauf que dbr_sdread pointe desormais vers une lecture
+// SD *par DMA* (dash_readSdDma ci-dessous) au lieu d'une copie processeur. Le
+// transfert DMA regenere l'IRQ carte que le moteur de Dash attend.
+
+.global dash_cmd_patch_entry
+.type dash_cmd_patch_entry, %function
+dash_cmd_patch_entry:
+    str  lr,  saved_lr
+    mov  r12, r0                 // r12 = offset ROM
+    ldr  r3,  dbr_fixcp15
+    blx  r3
+    mov  r0,  r12
+    ldr  r3,  dbr_remap
+    blx  r3                      // r0 = secteur SD
+    mov  r12, r0
+    ldr  r0,  dbr_global_ptr
+    ldr  r0,  [r0]               // r0 = ctx
+    ldr  r1,  [r0, #0x30]        // r1 = destination avancee
+    ldr  r2,  [r0, #0x34]        // r2 = secteurs restants
+    sub  r1,  r1, #0x200         // r1 = destination courante
+    add  r2,  r2, #1             // r2 = total a lire (ignore par la lecture DMA)
+    mov  r0,  r12                // r0 = secteur SD
+    ldr  r3,  dbr_sdread
+    blx  r3
+    ldr  pc,  saved_lr
+
+.balign 4
+saved_lr:         .word 0
+.global dbr_fixcp15
+dbr_fixcp15:      .word 0
+.global dbr_remap
+dbr_remap:        .word 0
+.global dbr_global_ptr
+dbr_global_ptr:   .word 0
+.global dbr_sdread
+dbr_sdread:       .word 0
+
+.pool
+
+// ---------------------------------------------------------------------------
+// Lecture SD d'UN secteur par DMA, autonome (aucune dependance a
+// MIi_CardDmaCopy32 ni a la chaine DMA de CardiTryReadCardDmaPatch).
+//
+//   r0 = secteur SD, r1 = destination, r2 = count (ignore : un secteur)
+//
+// Programme le canal DMA 0 avec le mot de controle propre de Dash (0xAF000001,
+// releve dans son pool en 0x0206D4A8 : mode carte DS, 32 bits, source fixe,
+// repetition, 1 mot par declenchement), arme AUXSPICNT bit 14, poste la
+// commande C0+secteur, puis lance ROMCTRL. La fin de transfert leve l'IRQ
+// carte (IF bit 19) que le handler de Dash (0x0206D1D8) attend.
+// ---------------------------------------------------------------------------
+.section "dash_readsddma", "ax"
+.syntax unified
+.arm
+
+.global dash_readSdDma
+.type dash_readSdDma, %function
+dash_readSdDma:
+    ldr  r3,  dsr_card_base      // r3 = 0x040001A0
+    ldr  r12, dsr_dataport       // r12 = 0x04100010 (port de donnees carte)
+    str  r12, [r3, #-0xF0]       // DMASAD (0x040000B0) : source fixe
+    str  r1,  [r3, #-0xEC]       // DMADAD (0x040000B4) : destination
+    ldr  r12, dsr_dmactrl        // r12 = 0xAF000001
+    str  r12, [r3, #-0xE8]       // DMACNT (0x040000B8) : arme le DMA
+    mov  r12, #0xC0
+    strb r12, [r3, #1]           // AUXSPICNT octet haut -> 0xC000
+    strb r12, [r3, #8]           // cmd[0] = C0
+    mov  r12, r0, lsr #24
+    strb r12, [r3, #9]           // cmd[1] = secteur >> 24
+    mov  r12, r0, lsr #16
+    strb r12, [r3, #0xA]         // cmd[2]
+    mov  r12, r0, lsr #8
+    strb r12, [r3, #0xB]         // cmd[3]
+    and  r12, r0, #0xFF
+    str  r12, [r3, #0xC]         // cmd[4..7] = dd 00 00 00
+    ldr  r12, dsr_romctrl        // 0xA1586000
+    str  r12, [r3, #4]           // ROMCTRL : demarrage du transfert
+    bx   lr
+
+.balign 4
+dsr_card_base:    .word 0x040001A0
+dsr_dataport:     .word 0x04100010
+dsr_dmactrl:      .word 0xAF000001
+dsr_romctrl:      .word 0xA1586000
+
+.pool
+.end

--- a/arm9/source/patches/platform/melonds/MelonDSLoaderPlatform.h
+++ b/arm9/source/patches/platform/melonds/MelonDSLoaderPlatform.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "../LoaderPlatform.h"
 #include "MelonDSReadSdPatchCode.h"
+#include "MelonDSReadSdDmaPatchCode.h"
 #include "MelonDSWriteSdPatchCode.h"
 
 /// @brief Implementation of LoaderPlatform for MelonDS
@@ -16,6 +17,16 @@ public:
         });
     }
 
+    const IReadSectorsDmaPatchCode* CreateSdReadDmaPatchCode(
+        PatchCodeCollection& patchCodeCollection, PatchHeap& patchHeap,
+        const void* miiCardDmaCopy32Ptr) const override
+    {
+        return patchCodeCollection.GetOrAddSharedPatchCode([&]
+        {
+            return new MelonDSReadSdDmaPatchCode(patchHeap, miiCardDmaCopy32Ptr);
+        });
+    }
+
     const IWriteSectorsPatchCode* CreateSdWritePatchCode(
         PatchCodeCollection& patchCodeCollection, PatchHeap& patchHeap) const override
     {
@@ -24,6 +35,8 @@ public:
             return new MelonDSWriteSdPatchCode(patchHeap);
         });
     }
+
+    bool HasDmaSdReads() const override { return true; }
 
     LoaderPlatformType GetPlatformType() const override { return LoaderPlatformType::Slot1; }
 };

--- a/arm9/source/patches/platform/melonds/MelonDSReadSdDmaPatchCode.h
+++ b/arm9/source/patches/platform/melonds/MelonDSReadSdDmaPatchCode.h
@@ -1,0 +1,30 @@
+#pragma once
+#include "sections.h"
+#include "patches/PatchCode.h"
+#include "../IReadSectorsDmaPatchCode.h"
+
+DEFINE_SECTION_SYMBOLS(melonds_readsddma);
+
+extern "C" void melonds_readSdDma(u32 srcSector, u32 previousSrcSector, u32 dmaChannel, void* dst);
+extern "C" void melonds_readSdDmaFinish(void);
+extern "C" u32 melonds_readsddma_miiCardDmaCopy32Ptr;
+
+class MelonDSReadSdDmaPatchCode : public PatchCode, public IReadSectorsDmaPatchCode
+{
+public:
+    MelonDSReadSdDmaPatchCode(PatchHeap& patchHeap, const void* miiCardDmaCopy32Ptr)
+        : PatchCode(SECTION_START(melonds_readsddma), SECTION_SIZE(melonds_readsddma), patchHeap)
+    {
+        melonds_readsddma_miiCardDmaCopy32Ptr = (u32)miiCardDmaCopy32Ptr;
+    }
+
+    const ReadSectorsDmaFunc GetReadSectorsDmaFunction() const override
+    {
+        return (const ReadSectorsDmaFunc)GetAddressAtTarget((void*)melonds_readSdDma);
+    }
+
+    const ReadSectorsDmaFinishFunc GetReadSectorsDmaFinishFunction() const override
+    {
+        return (const ReadSectorsDmaFinishFunc)GetAddressAtTarget((void*)melonds_readSdDmaFinish);
+    }
+};

--- a/arm9/source/patches/platform/melonds/MelonDSReadSdDmaPatchCode.s
+++ b/arm9/source/patches/platform/melonds/MelonDSReadSdDmaPatchCode.s
@@ -1,0 +1,77 @@
+.cpu arm946e-s
+.section "melonds_readsddma", "ax"
+.syntax unified
+.thumb
+
+// Lecture SD par DMA pour la plateforme MelonDS.
+//
+// Variante de melonds_readSd : au lieu de sonder DRQ et de recopier les mots
+// avec le processeur, on programme un canal DMA en mode de demarrage carte et
+// on arme l'interruption de fin de transfert. C'est ce qui permet aux jeux
+// pilotant eux-memes la cartouche (moteur DMA propre, hors CARDi_*) de
+// continuer a tourner : leur boucle est cadencee par cette interruption.
+//
+// L'emulation melonDS s'y prete : CartHomebrew::ROMCommandStart traite la
+// commande C0 sans examiner AUXSPICNT, NDSCartSlot::Interface::RaiseDRQ appelle
+// CheckDMA() sur donnee prete, et ROMEndTransfer leve l'IRQ si le bit 14
+// d'AUXSPICNT est arme.
+//
+// r0 = secteur source
+// r1 = secteur precedent (inutilise : pas de lecture sequentielle ici)
+// r2 = canal DMA
+// r3 = destination
+.global melonds_readSdDma
+.type melonds_readSdDma, %function
+melonds_readSdDma:
+    push {r4-r7,lr}
+    movs r5, r3                 // r5 = destination (r3 sert de registre de travail)
+    movs r6, r2                 // r6 = canal DMA
+
+    ldr r4, =0x040001A0
+    movs r3, #0xC0
+    strb r3, [r4,#1]            // AUXSPICNT : slot actif + IRQ de fin de transfert
+
+    // commande de lecture SD du secteur 0xaabbccdd : C0 aa bb cc dd 00 00 00
+    movs r3, #0xC0
+    strb r3, [r4,#0x8]
+    lsrs r3, r0, #24
+    strb r3, [r4,#0x9]
+    lsrs r3, r0, #16
+    strb r3, [r4,#0xA]
+    lsrs r3, r0, #8
+    strb r3, [r4,#0xB]
+    lsls r7, r0, #24
+    lsrs r7, r7, #24            // r7 = dd
+    str r7, [r4,#0xC]           // en petit-boutiste, l'octet bas vient en premier
+
+    // programme le DMA avant de lancer le transfert :
+    // MIi_CardDmaCopy32(canal, 0x04100010, destination, 512)
+    movs r0, r6
+    ldr r1, =0x04100010
+    movs r2, r5
+    movs r3, #1
+    lsls r3, r3, #9             // 512 octets
+    ldr r7, melonds_readsddma_miiCardDmaCopy32Ptr
+    blx r7
+
+    // lance le transfert : le DMA se declenche sur DRQ, l'IRQ arrive a la fin
+    ldr r3, =0xA1586000
+    str r3, [r4,#4]
+
+    pop {r4-r7,pc}
+
+// Fin de lot : la plateforme MelonDS ne gere pas de lecture sequentielle,
+// il n'y a donc rien a clore. Presente pour satisfaire l'interface.
+.global melonds_readSdDmaFinish
+.type melonds_readSdDmaFinish, %function
+melonds_readSdDmaFinish:
+    bx lr
+
+.balign 4
+.global melonds_readsddma_miiCardDmaCopy32Ptr
+melonds_readsddma_miiCardDmaCopy32Ptr:
+    .word 0
+
+.pool
+
+.end

--- a/dash-v11e.patch
+++ b/dash-v11e.patch
@@ -1,0 +1,120 @@
+diff --git a/arm9/source/patches/arm9/sdk2to4/CardiReadCardPatch.cpp b/arm9/source/patches/arm9/sdk2to4/CardiReadCardPatch.cpp
+index d48e7b5..b5020fe 100644
+--- a/arm9/source/patches/arm9/sdk2to4/CardiReadCardPatch.cpp
++++ b/arm9/source/patches/arm9/sdk2to4/CardiReadCardPatch.cpp
+@@ -9,6 +9,7 @@
+ #include "gameCode.h"
+ #include "CardiReadCardPatchAsm.h"
+ #include "CardiReadCardPatch.h"
++#include "DashCmdPatchCode.h"
+ 
+ static const u32 sCARDiReadCardPatternUnknown[] = { 0xE92D4FF0u, 0xE24DD004u, 0xE1A0A000u, 0xE59F90D8u };
+ static const u32 sCARDiReadCardPatternSdk20029A7[] = { 0xE92D4FF0u, 0xE24DD004u, 0xE1A0A000u, 0xE59F90E0u };
+@@ -293,4 +294,30 @@ void CardiReadCardPatch::ApplyPatch(PatchContext& patchContext)
+ 
+     memcpy(patch1Address, SECTION_START(patch_cardireadcard), patch1Size);
+     memcpy(patch4Address, SECTION_START(fixcp15), patch4Size);
++
++    // Pokemon Dash (APD*) : le jeu lit son systeme de fichiers via un moteur
++    // DMA carte qui lui est propre, hors des fonctions CARDi_* redirigees vers
++    // la SD. On intercepte l'assemblage de la commande carte 0xB7 a 0x0206D3A4
++    // pour y substituer une lecture SD, dans le contexte d'execution de Dash.
++    if ((patchContext.GetGameCode() & 0x00FFFFFF) == GAMECODE_NO_REGION("APD"))
++    {
++        u32 dashSize = SECTION_SIZE(dash_cmd_fix);
++        void* dashAddr = patchContext.GetPatchHeap().Alloc(dashSize);
++        dbr_fixcp15    = __patch_cardireadcard_fix_cp15_asm_address;
++        dbr_remap      = __patch_cardireadcard_rom_offset_to_sd_sector_asm_address;
++        dbr_sdread     = __patch_cardireadcard_sdread_asm_address;
++        dbr_global_ptr = *(u32*)0x0206D470u;   // = 0x020D6144, contexte du moteur
++        memcpy(dashAddr, SECTION_START(dash_cmd_fix), dashSize);
++
++        u32 trampolineEntry = (u32)&dash_cmd_patch_entry
++                              - (u32)SECTION_START(dash_cmd_fix) + (u32)dashAddr;
++
++        volatile u32* ii = (volatile u32*)0x0206D3A4u;
++        // ii[0] : lsr r1, r5, #8  -> inchange (r5 = offset ROM du secteur)
++        ii[1] = 0xE1A00005u;   // mov r0, r5   : passe l'offset au trampoline
++        u32 blOffset = ((trampolineEntry - ((u32)&ii[2] + 8u)) >> 2) & 0x00FFFFFFu;
++        ii[2] = 0xEB000000u | blOffset;
++        ii[3] = 0xE28FF058u;   // add pc, pc, #0x58 -> ii+27
++        ii[28] = 0xE1A00000u;  // nop : supprime le dernier octet de commande
++    }
+ }
+diff --git a/arm9/source/patches/arm9/sdk2to4/DashCmdPatchCode.h b/arm9/source/patches/arm9/sdk2to4/DashCmdPatchCode.h
+new file mode 100644
+index 0000000..f445043
+--- /dev/null
++++ b/arm9/source/patches/arm9/sdk2to4/DashCmdPatchCode.h
+@@ -0,0 +1,11 @@
++#pragma once
++#include "common.h"
++#include "sections.h"
++
++DEFINE_SECTION_SYMBOLS(dash_cmd_fix);
++
++extern "C" void dash_cmd_patch_entry();
++extern "C" u32 dbr_fixcp15;
++extern "C" u32 dbr_remap;
++extern "C" u32 dbr_sdread;
++extern "C" u32 dbr_global_ptr;
+diff --git a/arm9/source/patches/arm9/sdk2to4/DashCmdPatchCode.s b/arm9/source/patches/arm9/sdk2to4/DashCmdPatchCode.s
+new file mode 100644
+index 0000000..45f990b
+--- /dev/null
++++ b/arm9/source/patches/arm9/sdk2to4/DashCmdPatchCode.s
+@@ -0,0 +1,54 @@
++.cpu arm946e-s
++.section "dash_cmd_fix", "ax"
++.syntax unified
++.arm
++
++// Pokemon Dash (APDP) - lecture carte redirigee vers la SD.
++//
++// Point d'accroche : 0x0206D3A4, la ou le moteur propre a Dash assemble la
++// commande carte 0xB7. On y substitue une lecture SD, dans le contexte
++// d'execution de Dash lui-meme.
++//
++//   ctx   = [dbr_global_ptr]        (0x020D6144 = valeur du pool 0x0206D470)
++//   dst   = [ctx+0x30] - 0x200      (destination du secteur courant)
++//   count = [ctx+0x34] + 1          (secteurs restants + le courant)
++//
++// Zero pile : la pile IRQ de Dash est trop petite pour un push, lr est
++// sauvegarde dans la section elle-meme. Offsets de pool calcules par
++// l'assembleur via des etiquettes symboliques.
++
++.global dash_cmd_patch_entry
++.type dash_cmd_patch_entry, %function
++dash_cmd_patch_entry:
++    str  lr,  saved_lr
++    mov  r12, r0                 // r12 = offset ROM
++    ldr  r3,  dbr_fixcp15
++    blx  r3
++    mov  r0,  r12
++    ldr  r3,  dbr_remap
++    blx  r3                      // r0 = secteur SD
++    mov  r12, r0
++    ldr  r0,  dbr_global_ptr
++    ldr  r0,  [r0]               // r0 = ctx
++    ldr  r1,  [r0, #0x30]        // r1 = destination avancee
++    ldr  r2,  [r0, #0x34]        // r2 = secteurs restants
++    sub  r1,  r1, #0x200         // r1 = destination courante
++    add  r2,  r2, #1             // r2 = total a lire
++    mov  r0,  r12                // r0 = secteur SD
++    ldr  r3,  dbr_sdread
++    blx  r3
++    ldr  pc,  saved_lr
++
++.balign 4
++saved_lr:         .word 0
++.global dbr_fixcp15
++dbr_fixcp15:      .word 0
++.global dbr_remap
++dbr_remap:        .word 0
++.global dbr_global_ptr
++dbr_global_ptr:   .word 0
++.global dbr_sdread
++dbr_sdread:       .word 0
++
++.pool
++.end

--- a/dash-v19.patch
+++ b/dash-v19.patch
@@ -1,0 +1,198 @@
+diff --git a/arm9/source/patches/arm9/sdk2to4/CardiReadCardPatch.cpp b/arm9/source/patches/arm9/sdk2to4/CardiReadCardPatch.cpp
+index b5020fe..1111111 100644
+--- a/arm9/source/patches/arm9/sdk2to4/CardiReadCardPatch.cpp
++++ b/arm9/source/patches/arm9/sdk2to4/CardiReadCardPatch.cpp
+@@ -9,6 +9,7 @@
+ #include "gameCode.h"
+ #include "CardiReadCardPatchAsm.h"
+ #include "CardiReadCardPatch.h"
++#include "DashCmdPatchCode.h"
+ 
+ static const u32 sCARDiReadCardPatternUnknown[] = { 0xE92D4FF0u, 0xE24DD004u, 0xE1A0A000u, 0xE59F90D8u };
+ static const u32 sCARDiReadCardPatternSdk20029A7[] = { 0xE92D4FF0u, 0xE24DD004u, 0xE1A0A000u, 0xE59F90E0u };
+@@ -147,6 +148,18 @@
+         __patch_cardireadcard_rom_offset_to_sd_sector_asm_address = (u32)romOffsetToSdSectorPatchCode->GetRemapFunction();
+         __patch_cardireadcard_sdread_asm_address = (u32)sdReadPatchCode->GetReadSectorsFunction();
+     }
++    // v19 (Pokemon Dash) : la lecture SD par DMA vit dans sa propre section ;
++    // on l'alloue ici, tot, la ou le tas est peu fragmente (comme les autres
++    // patch codes), et non au site d'accroche Dash ou le plus grand bloc libre
++    // est reduit. dashReadDmaFn = adresse relogee de dash_readSdDma.
++    u32 dashReadDmaFn = 0;
++    if ((patchContext.GetGameCode() & 0x00FFFFFF) == GAMECODE_NO_REGION("APD"))
++    {
++        u32 dmaSize = SECTION_SIZE(dash_readsddma);
++        void* dmaAddr = patchContext.GetPatchHeap().Alloc(dmaSize);
++        memcpy(dmaAddr, SECTION_START(dash_readsddma), dmaSize);
++        dashReadDmaFn = (u32)&dash_readSdDma - (u32)SECTION_START(dash_readsddma) + (u32)dmaAddr;
++    }
+     u32 patch4Size = SECTION_SIZE(fixcp15);
+     void* patch4Address = patchContext.GetPatchHeap().Alloc(patch4Size);
+     __patch_cardireadcard_fix_cp15_asm_address = (u32)&fix_cp15_asm - (u32)SECTION_START(fixcp15) + (u32)patch4Address;
+@@ -293,4 +306,35 @@
+ 
+     memcpy(patch1Address, SECTION_START(patch_cardireadcard), patch1Size);
+     memcpy(patch4Address, SECTION_START(fixcp15), patch4Size);
++
++    // Pokemon Dash (APD*) : le jeu lit son systeme de fichiers via un moteur
++    // DMA carte qui lui est propre, hors des fonctions CARDi_* redirigees vers
++    // la SD. On intercepte l'assemblage de la commande carte 0xB7 a 0x0206D3A4
++    // pour y substituer une lecture SD, dans le contexte d'execution de Dash.
++    // v19 : la lecture est par DMA (dashReadDmaFn) et non plus une copie
++    // processeur, afin de regenerer l'IRQ carte attendue par le moteur.
++    // dashReadDmaFn == 0 => l'alloc precoce a echoue : on n'accroche pas, Dash
++    // demarre comme non-patche (temoin d'echec lisible, pas de blx 0).
++    if (dashReadDmaFn != 0u
++        && (patchContext.GetGameCode() & 0x00FFFFFF) == GAMECODE_NO_REGION("APD"))
++    {
++        u32 dashSize = SECTION_SIZE(dash_cmd_fix);
++        void* dashAddr = patchContext.GetPatchHeap().Alloc(dashSize);
++        dbr_fixcp15    = __patch_cardireadcard_fix_cp15_asm_address;
++        dbr_remap      = __patch_cardireadcard_rom_offset_to_sd_sector_asm_address;
++        dbr_sdread     = dashReadDmaFn;
++        dbr_global_ptr = *(u32*)0x0206D470u;   // = 0x020D6144, contexte du moteur
++        memcpy(dashAddr, SECTION_START(dash_cmd_fix), dashSize);
++
++        u32 trampolineEntry = (u32)&dash_cmd_patch_entry
++                              - (u32)SECTION_START(dash_cmd_fix) + (u32)dashAddr;
++
++        volatile u32* ii = (volatile u32*)0x0206D3A4u;
++        // ii[0] : lsr r1, r5, #8  -> inchange (r5 = offset ROM du secteur)
++        ii[1] = 0xE1A00005u;   // mov r0, r5   : passe l'offset au trampoline
++        u32 blOffset = ((trampolineEntry - ((u32)&ii[2] + 8u)) >> 2) & 0x00FFFFFFu;
++        ii[2] = 0xEB000000u | blOffset;
++        ii[3] = 0xE28FF058u;   // add pc, pc, #0x58 -> ii+27
++        ii[28] = 0xE1A00000u;  // nop : supprime le dernier octet de commande
++    }
+ }
+diff --git a/arm9/source/patches/arm9/sdk2to4/DashCmdPatchCode.h b/arm9/source/patches/arm9/sdk2to4/DashCmdPatchCode.h
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/arm9/source/patches/arm9/sdk2to4/DashCmdPatchCode.h
+@@ -0,0 +1,13 @@
++#pragma once
++#include "common.h"
++#include "sections.h"
++
++DEFINE_SECTION_SYMBOLS(dash_cmd_fix);
++DEFINE_SECTION_SYMBOLS(dash_readsddma);
++
++extern "C" void dash_cmd_patch_entry();
++extern "C" void dash_readSdDma(u32 srcSector, void* dst, u32 count);
++extern "C" u32 dbr_fixcp15;
++extern "C" u32 dbr_remap;
++extern "C" u32 dbr_global_ptr;
++extern "C" u32 dbr_sdread;
+diff --git a/arm9/source/patches/arm9/sdk2to4/DashCmdPatchCode.s b/arm9/source/patches/arm9/sdk2to4/DashCmdPatchCode.s
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/arm9/source/patches/arm9/sdk2to4/DashCmdPatchCode.s
+@@ -0,0 +1,106 @@
++.cpu arm946e-s
++.section "dash_cmd_fix", "ax"
++.syntax unified
++.arm
++
++// Pokemon Dash (APDP) - lecture carte redirigee vers la SD.
++//
++// Point d'accroche : 0x0206D3A4, la ou le moteur propre a Dash assemble la
++// commande carte 0xB7. On y substitue une lecture SD, dans le contexte
++// d'execution de Dash lui-meme.
++//
++//   ctx   = [dbr_global_ptr]        (0x020D6144 = valeur du pool 0x0206D470)
++//   dst   = [ctx+0x30] - 0x200      (destination du secteur courant)
++//   count = [ctx+0x34] + 1          (secteurs restants + le courant)
++//
++// Zero pile : la pile IRQ de Dash est trop petite pour un push, lr est
++// sauvegarde dans la section elle-meme. Offsets de pool calcules par
++// l'assembleur via des etiquettes symboliques.
++//
++// v19 : identique a v11e, sauf que dbr_sdread pointe desormais vers une lecture
++// SD *par DMA* (dash_readSdDma ci-dessous) au lieu d'une copie processeur. Le
++// transfert DMA regenere l'IRQ carte que le moteur de Dash attend.
++
++.global dash_cmd_patch_entry
++.type dash_cmd_patch_entry, %function
++dash_cmd_patch_entry:
++    str  lr,  saved_lr
++    mov  r12, r0                 // r12 = offset ROM
++    ldr  r3,  dbr_fixcp15
++    blx  r3
++    mov  r0,  r12
++    ldr  r3,  dbr_remap
++    blx  r3                      // r0 = secteur SD
++    mov  r12, r0
++    ldr  r0,  dbr_global_ptr
++    ldr  r0,  [r0]               // r0 = ctx
++    ldr  r1,  [r0, #0x30]        // r1 = destination avancee
++    ldr  r2,  [r0, #0x34]        // r2 = secteurs restants
++    sub  r1,  r1, #0x200         // r1 = destination courante
++    add  r2,  r2, #1             // r2 = total a lire (ignore par la lecture DMA)
++    mov  r0,  r12                // r0 = secteur SD
++    ldr  r3,  dbr_sdread
++    blx  r3
++    ldr  pc,  saved_lr
++
++.balign 4
++saved_lr:         .word 0
++.global dbr_fixcp15
++dbr_fixcp15:      .word 0
++.global dbr_remap
++dbr_remap:        .word 0
++.global dbr_global_ptr
++dbr_global_ptr:   .word 0
++.global dbr_sdread
++dbr_sdread:       .word 0
++
++.pool
++
++// ---------------------------------------------------------------------------
++// Lecture SD d'UN secteur par DMA, autonome (aucune dependance a
++// MIi_CardDmaCopy32 ni a la chaine DMA de CardiTryReadCardDmaPatch).
++//
++//   r0 = secteur SD, r1 = destination, r2 = count (ignore : un secteur)
++//
++// Programme le canal DMA 0 avec le mot de controle propre de Dash (0xAF000001,
++// releve dans son pool en 0x0206D4A8 : mode carte DS, 32 bits, source fixe,
++// repetition, 1 mot par declenchement), arme AUXSPICNT bit 14, poste la
++// commande C0+secteur, puis lance ROMCTRL. La fin de transfert leve l'IRQ
++// carte (IF bit 19) que le handler de Dash (0x0206D1D8) attend.
++// ---------------------------------------------------------------------------
++.section "dash_readsddma", "ax"
++.syntax unified
++.arm
++
++.global dash_readSdDma
++.type dash_readSdDma, %function
++dash_readSdDma:
++    ldr  r3,  dsr_card_base      // r3 = 0x040001A0
++    ldr  r12, dsr_dataport       // r12 = 0x04100010 (port de donnees carte)
++    str  r12, [r3, #-0xF0]       // DMASAD (0x040000B0) : source fixe
++    str  r1,  [r3, #-0xEC]       // DMADAD (0x040000B4) : destination
++    ldr  r12, dsr_dmactrl        // r12 = 0xAF000001
++    str  r12, [r3, #-0xE8]       // DMACNT (0x040000B8) : arme le DMA
++    mov  r12, #0xC0
++    strb r12, [r3, #1]           // AUXSPICNT octet haut -> 0xC000
++    strb r12, [r3, #8]           // cmd[0] = C0
++    mov  r12, r0, lsr #24
++    strb r12, [r3, #9]           // cmd[1] = secteur >> 24
++    mov  r12, r0, lsr #16
++    strb r12, [r3, #0xA]         // cmd[2]
++    mov  r12, r0, lsr #8
++    strb r12, [r3, #0xB]         // cmd[3]
++    and  r12, r0, #0xFF
++    str  r12, [r3, #0xC]         // cmd[4..7] = dd 00 00 00
++    ldr  r12, dsr_romctrl        // 0xA1586000
++    str  r12, [r3, #4]           // ROMCTRL : demarrage du transfert
++    bx   lr
++
++.balign 4
++dsr_card_base:    .word 0x040001A0
++dsr_dataport:     .word 0x04100010
++dsr_dmactrl:      .word 0xAF000001
++dsr_romctrl:      .word 0xA1586000
++
++.pool
++.end

--- a/melonds-dma-sd-read.patch
+++ b/melonds-dma-sd-read.patch
@@ -1,0 +1,156 @@
+diff --git a/arm9/source/patches/platform/melonds/MelonDSLoaderPlatform.h b/arm9/source/patches/platform/melonds/MelonDSLoaderPlatform.h
+index 42059cc..5b82e58 100644
+--- a/arm9/source/patches/platform/melonds/MelonDSLoaderPlatform.h
++++ b/arm9/source/patches/platform/melonds/MelonDSLoaderPlatform.h
+@@ -1,6 +1,7 @@
+ #pragma once
+ #include "../LoaderPlatform.h"
+ #include "MelonDSReadSdPatchCode.h"
++#include "MelonDSReadSdDmaPatchCode.h"
+ #include "MelonDSWriteSdPatchCode.h"
+ 
+ /// @brief Implementation of LoaderPlatform for MelonDS
+@@ -16,6 +17,16 @@ public:
+         });
+     }
+ 
++    const IReadSectorsDmaPatchCode* CreateSdReadDmaPatchCode(
++        PatchCodeCollection& patchCodeCollection, PatchHeap& patchHeap,
++        const void* miiCardDmaCopy32Ptr) const override
++    {
++        return patchCodeCollection.GetOrAddSharedPatchCode([&]
++        {
++            return new MelonDSReadSdDmaPatchCode(patchHeap, miiCardDmaCopy32Ptr);
++        });
++    }
++
+     const IWriteSectorsPatchCode* CreateSdWritePatchCode(
+         PatchCodeCollection& patchCodeCollection, PatchHeap& patchHeap) const override
+     {
+@@ -25,5 +36,7 @@ public:
+         });
+     }
+ 
++    bool HasDmaSdReads() const override { return true; }
++
+     LoaderPlatformType GetPlatformType() const override { return LoaderPlatformType::Slot1; }
+ };
+diff --git a/arm9/source/patches/platform/melonds/MelonDSReadSdDmaPatchCode.h b/arm9/source/patches/platform/melonds/MelonDSReadSdDmaPatchCode.h
+new file mode 100644
+index 0000000..54a3934
+--- /dev/null
++++ b/arm9/source/patches/platform/melonds/MelonDSReadSdDmaPatchCode.h
+@@ -0,0 +1,30 @@
++#pragma once
++#include "sections.h"
++#include "patches/PatchCode.h"
++#include "../IReadSectorsDmaPatchCode.h"
++
++DEFINE_SECTION_SYMBOLS(melonds_readsddma);
++
++extern "C" void melonds_readSdDma(u32 srcSector, u32 previousSrcSector, u32 dmaChannel, void* dst);
++extern "C" void melonds_readSdDmaFinish(void);
++extern "C" u32 melonds_readsddma_miiCardDmaCopy32Ptr;
++
++class MelonDSReadSdDmaPatchCode : public PatchCode, public IReadSectorsDmaPatchCode
++{
++public:
++    MelonDSReadSdDmaPatchCode(PatchHeap& patchHeap, const void* miiCardDmaCopy32Ptr)
++        : PatchCode(SECTION_START(melonds_readsddma), SECTION_SIZE(melonds_readsddma), patchHeap)
++    {
++        melonds_readsddma_miiCardDmaCopy32Ptr = (u32)miiCardDmaCopy32Ptr;
++    }
++
++    const ReadSectorsDmaFunc GetReadSectorsDmaFunction() const override
++    {
++        return (const ReadSectorsDmaFunc)GetAddressAtTarget((void*)melonds_readSdDma);
++    }
++
++    const ReadSectorsDmaFinishFunc GetReadSectorsDmaFinishFunction() const override
++    {
++        return (const ReadSectorsDmaFinishFunc)GetAddressAtTarget((void*)melonds_readSdDmaFinish);
++    }
++};
+diff --git a/arm9/source/patches/platform/melonds/MelonDSReadSdDmaPatchCode.s b/arm9/source/patches/platform/melonds/MelonDSReadSdDmaPatchCode.s
+new file mode 100644
+index 0000000..2c92f51
+--- /dev/null
++++ b/arm9/source/patches/platform/melonds/MelonDSReadSdDmaPatchCode.s
+@@ -0,0 +1,77 @@
++.cpu arm946e-s
++.section "melonds_readsddma", "ax"
++.syntax unified
++.thumb
++
++// Lecture SD par DMA pour la plateforme MelonDS.
++//
++// Variante de melonds_readSd : au lieu de sonder DRQ et de recopier les mots
++// avec le processeur, on programme un canal DMA en mode de demarrage carte et
++// on arme l'interruption de fin de transfert. C'est ce qui permet aux jeux
++// pilotant eux-memes la cartouche (moteur DMA propre, hors CARDi_*) de
++// continuer a tourner : leur boucle est cadencee par cette interruption.
++//
++// L'emulation melonDS s'y prete : CartHomebrew::ROMCommandStart traite la
++// commande C0 sans examiner AUXSPICNT, NDSCartSlot::Interface::RaiseDRQ appelle
++// CheckDMA() sur donnee prete, et ROMEndTransfer leve l'IRQ si le bit 14
++// d'AUXSPICNT est arme.
++//
++// r0 = secteur source
++// r1 = secteur precedent (inutilise : pas de lecture sequentielle ici)
++// r2 = canal DMA
++// r3 = destination
++.global melonds_readSdDma
++.type melonds_readSdDma, %function
++melonds_readSdDma:
++    push {r4-r7,lr}
++    movs r5, r3                 // r5 = destination (r3 sert de registre de travail)
++    movs r6, r2                 // r6 = canal DMA
++
++    ldr r4, =0x040001A0
++    movs r3, #0xC0
++    strb r3, [r4,#1]            // AUXSPICNT : slot actif + IRQ de fin de transfert
++
++    // commande de lecture SD du secteur 0xaabbccdd : C0 aa bb cc dd 00 00 00
++    movs r3, #0xC0
++    strb r3, [r4,#0x8]
++    lsrs r3, r0, #24
++    strb r3, [r4,#0x9]
++    lsrs r3, r0, #16
++    strb r3, [r4,#0xA]
++    lsrs r3, r0, #8
++    strb r3, [r4,#0xB]
++    lsls r7, r0, #24
++    lsrs r7, r7, #24            // r7 = dd
++    str r7, [r4,#0xC]           // en petit-boutiste, l'octet bas vient en premier
++
++    // programme le DMA avant de lancer le transfert :
++    // MIi_CardDmaCopy32(canal, 0x04100010, destination, 512)
++    movs r0, r6
++    ldr r1, =0x04100010
++    movs r2, r5
++    movs r3, #1
++    lsls r3, r3, #9             // 512 octets
++    ldr r7, melonds_readsddma_miiCardDmaCopy32Ptr
++    blx r7
++
++    // lance le transfert : le DMA se declenche sur DRQ, l'IRQ arrive a la fin
++    ldr r3, =0xA1586000
++    str r3, [r4,#4]
++
++    pop {r4-r7,pc}
++
++// Fin de lot : la plateforme MelonDS ne gere pas de lecture sequentielle,
++// il n'y a donc rien a clore. Presente pour satisfaire l'interface.
++.global melonds_readSdDmaFinish
++.type melonds_readSdDmaFinish, %function
++melonds_readSdDmaFinish:
++    bx lr
++
++.balign 4
++.global melonds_readsddma_miiCardDmaCopy32Ptr
++melonds_readsddma_miiCardDmaCopy32Ptr:
++    .word 0
++
++.pool
++
++.end


### PR DESCRIPTION
Background

Pokémon Dash has never booted under any SD loader (nds-bootstrap #286, open since 2018; pico-loader #5). Root cause: Dash reads its filesystem through its own interrupt-driven card-DMA engine, outside the NitroSDK CARDi_* functions that loaders redirect to SD. A plain CPU-copy redirect (v11e) loads the data correctly but never raises the card IRQ the engine waits on, so the engine sleeps forever on mcr p15,0,r0,c7,c0,4.

What was done: DMA-read patch (v19)

v19 reuses v11e's proven hook at 0x0206D3A4 unchanged (this hook applies to Dash, unlike CardiTryReadCardDmaPatch, which is never reached for APDP). The only change: the read function it calls now performs a card-mode DMA read instead of a CPU copy, so it regenerates the card transfer-complete IRQ.

Key design points:

Self-contained DMA read (new dash_readsddma section): programs DMA channel 0 directly — DMASAD=0x04100010 (fixed source), DMADAD=dst, DMACNT=0xAF000001 (Dash's own control word, read from its pool at 0x0206D4A8: gamecard mode 5, 32-bit, source-fixed, repeat, 1 word/DRQ), AUXSPICNT high byte 0xC0 to arm the transfer IRQ, command C0+sector to 0x040001A8, start ROMCTRL=0xA1586000. No MIi_CardDmaCopy32, no dependency on the platform DMA chain.
The DMA-read section is allocated early (unfragmented); the tiny trampoline (92 bytes) fits the constrained patch-heap site. Guarded so an allocation failure boots unpatched (diagnosable) rather than crashing.
Result — the 2018 read bug is solved (measured under GDB)
Hook installed at 0x0206D3A4.
FAT loads correctly: 0x23B2340 = 0x00078200 0x000A2AE4.
Card IRQ is regenerated: handler 0x0206D1D8 is hit repeatedly.
The engine advances and drains the whole batch: ctx+0x34 goes 0x17 → 0x00.
Native end-of-batch cleanup (0x0206D294 → 0x0206D708) runs cleanly.

Dash now runs further than any prior attempt: it loads its filesystem and proceeds into game initialization.

The remaining wall (a distinct, later layer)

After the filesystem loads, Dash data-aborts inside its directory reader. Fault: 0x0209DED4 ldrh r0,[r0] inside a memcpy (0x0209DE84), with source r0 = 0x663BEFBD (unmapped).

Proven arithmetic of the bad pointer (0x0209FAD8): cursor = [stream+0x28] + word_read_at([stream+0x28] + index*8). With index 0: [0x23B8358] = 0x64006C65 (raw filename bytes "el\0d"), so cursor = 0x23B8358 + 0x64006C65 = 0x663BEFBD.

In other words, the reader reads its name-offset from inside the name pool itself, instead of from a name-offset table. The loaded data is correct and resident (filenames well-formed; a 12-byte-entry table of file offsets sits at 0x23B6F20). The stream (0x20DA3D4) is a sliding-window decompressor: [+0x20]/[+0x28] are two contiguous buffers; [+0x28]=0x23B8358 is the decompressed name pool.

Correct base found, and lure test (results)

A wide RAM dump (0x23A0000–0x23D0000) locates the correct name base: the table's name-offset column (0x3F8A, 0x3FA0, …), added to 0x23AEE60, maps exactly onto real names (0x23AEE60 + 0x3F8A = 0x23B2DEA = "fr/mdl_i_number_r.rel", 16 in a row). So the correct cursor is 0x23AEE60 + offset; the reader uses [stream+0x28] = 0x23B8358 — wrong by 0x94F8.

DMA / Pico Loader ruled out (proven): [stream+0x28] is a legitimate buffer pointer (= [stream+0x20] + [stream+0x24]), copied verbatim from a parent struct (0x0206E228–38), and the resident directory is internally consistent (offsets → correct names, 16/16). The DMA copies bytes verbatim to Dash-chosen addresses; it does not restructure or misplace anything. The data is correct; the bug is a pointer Dash computes.

Live lure test (GDB): forcing the cursor register at the store site (set $r0 = 0x23B2DEA at 0x0209FAD8) passed the name-read abort — the redirect concept works. But the wall moved to the file loader (0x020A0238 ldr r1,[r6,#0x10], r6=0, a null lookup result), because the reader's index is 0 ([reader+0x30]=0): forcing entry 0 feeds Dash the wrong file regardless of what it searched for.

ROM-verified root cause

With the ROM: the stream is the NDS FAT/FNT reader (its four fields match the NDS header exactly), but its buffers actually hold NDS file id=5 = "NITRO Archive 1" (Dash's model/resource archive: .rel/.blk), loaded at RAM 0x23AEE60 = ROM 0xD7000. The real NDS FNT is not resident. Dash is looking up sound_data.sdat (read from [reader+0x38]; the state-4 op at 0x209F738 tokenises a path by /,\), which is NDS file id=103 (ROM 0x843C00) and lives in the real FNT — not in file id=5.

Two interlocking anomalies:

Directory pointer mis-positioned. [stream+0x28]=0x23B8358 is internal offset 0x94F8 of file id=5 — inside its name pool — whereas its directory table sits at offset 0x20 (12-byte entries nameOffset, dataOffset, size; RAM 0x23AEE80). The reader reads name bytes as a nameOffset → cursor = 0x23B8358 + 0x64006C65 = 0x663BEFBD → abort.
Wrong archive queried. The reader searches the model archive (id=5) for a sound file that lives elsewhere in the NDS filesystem.
Read trace (decisive) and scenario B

A GDB read-trace (hook at 0x0206D3A4, logging ROM offset vs RAM destination) shows the boot sequence: the FAT loads correctly (ROM 0xD3600 → RAM 0x23B2340), then the NDS FNT (ROM 0xCB800) is never read, and file id=5 (ROM 0xD7000) streams into RAM 0x23AEE60+, whose region overlaps the reader's buffers (0x23B5380/0x23B8358 = id=5 internal offsets 0x6520/0x94F8). So the reader's FNT buffer is filled with id=5, never the FNT. The crash occurs during the id=5 search, before any FNT resolution — which is why the FNT is never read.

The file loader then blindly dereferences its result with no null check (0x20A020C ldr r6,[r7,#8] … 0x20A0238 ldr r1,[r6,#0x10]), so Dash assumes sound_data.sdat is found. This rules out the "graceful fallback" hypothesis: simply suppressing the crash is not enough — the file must be found. Therefore the reader must search the NDS FNT (which contains sound_data.sdat, id=103), and the real fix is to get the correct FNT into the reader's buffer — i.e. understand why the FNT is never read (a stale "already loaded" flag / inherited stream state) or why id=5 overwrites the FNT buffer. This is Dash's filesystem mount/streaming layer, which is vtable-dispatched (cannot be traced statically) and hard to trace on this debugger (breakpoints on the read routine freeze GDB; watchpoints and RAM writes don't work) — so it needs a better-instrumented emulator to resolve.

Deliverables
dash-v19.patch (applies/reverses cleanly on ad20556).
melonds-dma-sd-read.patch (adds melonds_readSdDma to the MELONDS platform; independently useful, worth upstreaming).
trace-fnt.gdb (read-trace script: ROM offset → RAM destination, per read).


ROM: Pokémon Dash (PAL, game code APDP), 32 MB, MD5 e77bc27ea6e5702ef0ca63d79d8ad80d. Base: pico-loader @ ad20556, target melonDS (PICO_PLATFORM=MELONDS), debugged with gdb-multiarch.


[dash-v19.patch](https://github.com/user-attachments/files/30860486/dash-v19.patch)
[melonds-dma-sd-read.patch](https://github.com/user-attachments/files/30860487/melonds-dma-sd-read.patch)
[trace-fnt.zip](https://github.com/user-attachments/files/30860634/trace-fnt.zip)