### PR TITLE
acekard-common: implement 0xB8 command - cardWaitReady

### DIFF
--- a/arm9/source/patches/platform/acekard-common/IoRpgCardWaitReadyPatchCode.h
+++ b/arm9/source/patches/platform/acekard-common/IoRpgCardWaitReadyPatchCode.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "sections.h"
+#include "thumbInstructions.h"
+#include "patches/PatchCode.h"
+
+DEFINE_SECTION_SYMBOLS(iorpg_cardwaitready);
+
+extern "C" void iorpg_cardWaitReady(void);
+
+class IoRpgCardWaitReadyPatchCode : public PatchCode
+{
+public:
+    IoRpgCardWaitReadyPatchCode(PatchHeap& patchHeap)
+        : PatchCode(SECTION_START(iorpg_cardwaitready), SECTION_SIZE(iorpg_cardwaitready), patchHeap) { }
+
+    const void* GetCardWaitReadyFunction() const
+    {
+        return GetAddressAtTarget((void*)iorpg_cardWaitReady);
+    }
+};

--- a/arm9/source/patches/platform/acekard-common/IoRpgCardWaitReadyPatchCode.s
+++ b/arm9/source/patches/platform/acekard-common/IoRpgCardWaitReadyPatchCode.s
@@ -1,0 +1,39 @@
+.cpu arm7tdmi
+.syntax unified
+.section "iorpg_cardwaitready", "ax"
+.thumb
+
+.global iorpg_cardWaitReady
+.type iorpg_cardWaitReady, %function
+iorpg_cardWaitReady:
+    push {r5-r7,lr}
+
+    ldr r5, =0x04100010
+
+    // Reset cmd buffer
+    ldr r6, =0xB8B8B8B8
+    str r6, [r4,#0x8]
+    str r6, [r4,#0xC]
+
+iorpg_cardWaitReady_read_loop:
+    ldr r6, =0xA7406004
+    str r6, [r4, #0x4]
+
+iorpg_cardWaitReady_read_wait_data_ready:
+    // Check MCCNT1_DATA_READY
+    ldrb r7, [r4,#6]
+    lsrs r7, r7, #8 // check if data is ready
+    bcc iorpg_cardWaitReady_read_wait_data_ready // if not, loop
+
+    ldr r7, [r5]
+    ldr r6, =0xFC2 // card ID
+    cmp r7, r6
+    bne iorpg_cardWaitReady_read_loop
+
+    pop {r5-r7,pc}
+
+.balign 4
+
+.pool
+
+.end

--- a/arm9/source/patches/platform/acekard-common/IoRpgLoaderPlatform.h
+++ b/arm9/source/patches/platform/acekard-common/IoRpgLoaderPlatform.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "../LoaderPlatform.h"
 #include "IoRpgDefinitions.h"
+#include "IoRpgCardWaitReadyPatchCode.h"
 #include "IoRpgSdHelperPatchCode.h"
 #include "IoRpgSdReadLoopPatchCode.h"
 #include "IoRpgReadSdPatchCode.h"
@@ -26,6 +27,7 @@ public:
         return patchCodeCollection.GetOrAddSharedPatchCode([&]
         {
             return new IoRpgReadSdPatchCode(patchHeap,
+                CreateCardWaitReadyPatchCode(patchCodeCollection, patchHeap),
                 CreateSdHelperPatchCode(patchCodeCollection, patchHeap),
                 patchCodeCollection.GetOrAddSharedPatchCode([&]
                 {
@@ -44,6 +46,7 @@ public:
     {
         return patchCodeCollection.AddUniquePatchCode<IoRpgReadSdDmaPatchCode>(
             patchHeap,
+            CreateCardWaitReadyPatchCode(patchCodeCollection, patchHeap),
             CreateSdHelperPatchCode(patchCodeCollection, patchHeap),
             patchCodeCollection.GetOrAddSharedPatchCode([&]
             {
@@ -81,6 +84,15 @@ protected:
             return patchCodeCollection.GetOrAddSharedPatchCode([&]
             {
                 return new IoRpgSdHelperPatchCode(patchHeap, GetPlatformSpecifics());
+            });
+        }
+
+    const IoRpgCardWaitReadyPatchCode* CreateCardWaitReadyPatchCode(
+        PatchCodeCollection& patchCodeCollection, PatchHeap& patchHeap) const
+        {
+            return patchCodeCollection.GetOrAddSharedPatchCode([&]
+            {
+                return new IoRpgCardWaitReadyPatchCode(patchHeap);
             });
         }
 

--- a/arm9/source/patches/platform/acekard-common/IoRpgReadSdDmaPatchCode.h
+++ b/arm9/source/patches/platform/acekard-common/IoRpgReadSdDmaPatchCode.h
@@ -13,6 +13,7 @@ extern "C" void iorpg_finishReadSdDma(void);
 extern "C" void iorpg_dmaStartTransfer(u32 srcSector, u32 previousSrcSector, u32 dmaChannel, void* dst);
 
 extern u32 iorpg_readSdDma_sendSdioCommand_address;
+extern u32 iorpg_readSdDma_cardWaitReady_address;
 extern u32 iorpg_readSdDma_sdWaitForState_address;
 extern u32 iorpg_readSdDma_cmd12_command;
 extern u32 iorpg_readSdDma_cmd18_command;
@@ -40,12 +41,14 @@ class IoRpgReadSdDmaPatchCode : public PatchCode, public IReadSectorsDmaPatchCod
 {
 public:
     IoRpgReadSdDmaPatchCode(PatchHeap& patchHeap,
+        const IoRpgCardWaitReadyPatchCode* iorpgCardWaitReadyPatchCode,
         const IoRpgSdHelperPatchCode* iorpgSdHelperPatchCode,
         const IoRpgDmaStartTransferPatchCode* IoRpgDmaStartTransferPatchCode,
         const IoRpgPlatformSpecifics& platformSpecifics)
         : PatchCode(SECTION_START(iorpg_readsddma), SECTION_SIZE(iorpg_readsddma), patchHeap)
     {
         iorpg_readSdDma_sendSdioCommand_address = (u32)iorpgSdHelperPatchCode->GetSendSdioCommandFunction();
+        iorpg_readSdDma_cardWaitReady_address = (u32)iorpgCardWaitReadyPatchCode->GetCardWaitReadyFunction();
         iorpg_readSdDma_sdWaitForState_address = (u32)iorpgSdHelperPatchCode->GetSdWaitForStateFunction();
         iorpg_readSdDma_dmaStartTransfer_address = (u32)IoRpgDmaStartTransferPatchCode->GetDmaStartTransferFunction();
         iorpg_readSdDma_cmd12_command = platformSpecifics.cmd12Command;

--- a/arm9/source/patches/platform/acekard-common/IoRpgReadSdDmaPatchCode.s
+++ b/arm9/source/patches/platform/acekard-common/IoRpgReadSdDmaPatchCode.s
@@ -37,6 +37,10 @@ iorpg_readSdDma_sdsc_shift:
     ldr r5, iorpg_readSdDma_sendSdioCommand_address
     blx r5
 
+    ldr r5, iorpg_readSdDma_cardWaitReady_address
+    blx r5
+    b readDataWithDma
+
 waitSdState:
     // Wait for SD state
     movs r0, #7
@@ -48,6 +52,10 @@ readDataWithDma:
     bx r5
 
 .balign 4
+
+.global iorpg_readSdDma_cardWaitReady_address
+iorpg_readSdDma_cardWaitReady_address:
+    .word 0
 
 .global iorpg_readSdDma_dmaStartTransfer_address
 iorpg_readSdDma_dmaStartTransfer_address:

--- a/arm9/source/patches/platform/acekard-common/IoRpgReadSdPatchCode.h
+++ b/arm9/source/patches/platform/acekard-common/IoRpgReadSdPatchCode.h
@@ -12,7 +12,7 @@ extern "C" void iorpg_readSd(u32 srcSector, void* dst, u32 sectorCount);
 
 extern u32 iorpg_readSd_sendSdioCommand_address;
 extern u32 iorpg_readSd_sdReadLoop_address;
-extern u32 iorpg_readSd_sdWaitForState_address;
+extern u32 iorpg_readSd_cardWaitReady_address;
 extern u32 iorpg_readSd_cmd12_command;
 extern u32 iorpg_readSd_cmd18_command;
 extern u16 iorpg_readSd_sdsc_shift;
@@ -21,6 +21,7 @@ class IoRpgReadSdPatchCode : public PatchCode, public IReadSectorsPatchCode
 {
 public:
     IoRpgReadSdPatchCode(PatchHeap& patchHeap,
+        const IoRpgCardWaitReadyPatchCode* iorpgCardWaitReadyPatchCode,
         const IoRpgSdHelperPatchCode* iorpgSdHelperPatchCode,
         const IoRpgSdReadLoopPatchCode* iorpgSdReadLoopPatchCode,
         const IoRpgPlatformSpecifics& platformSpecifics)
@@ -28,7 +29,7 @@ public:
     {
         iorpg_readSd_sendSdioCommand_address = (u32)iorpgSdHelperPatchCode->GetSendSdioCommandFunction();
         iorpg_readSd_sdReadLoop_address = (u32)iorpgSdReadLoopPatchCode->GetSdReadLoopFunction();
-        iorpg_readSd_sdWaitForState_address = (u32)iorpgSdHelperPatchCode->GetSdWaitForStateFunction();
+        iorpg_readSd_cardWaitReady_address = (u32)iorpgCardWaitReadyPatchCode->GetCardWaitReadyFunction();
         iorpg_readSd_cmd12_command = platformSpecifics.cmd12Command;
         iorpg_readSd_cmd18_command = platformSpecifics.cmd18Command;
     }

--- a/arm9/source/patches/platform/acekard-common/IoRpgReadSdPatchCode.s
+++ b/arm9/source/patches/platform/acekard-common/IoRpgReadSdPatchCode.s
@@ -25,11 +25,8 @@ iorpg_readSd_sdsc_shift:
     ldr r3, iorpg_readSd_sendSdioCommand_address
     bl blx_r3
 
-    // Wait for SD state
-    movs r0, #7
-    ldr r3, iorpg_readSd_sdWaitForState_address
+    ldr r3, iorpg_readSd_cardWaitReady_address
     bl blx_r3
-
     pop {r0-r1}
 
     // Read sectors. Parameters identical to readSd
@@ -58,8 +55,8 @@ iorpg_readSd_sendSdioCommand_address:
 iorpg_readSd_sdReadLoop_address:
     .word 0
 
-.global iorpg_readSd_sdWaitForState_address
-iorpg_readSd_sdWaitForState_address:
+.global iorpg_readSd_cardWaitReady_address
+iorpg_readSd_cardWaitReady_address:
     .word 0
 
 .global iorpg_readSd_cmd18_command

--- a/arm9/source/patches/platform/acekard-common/IoRpgSdHelperPatchCode.s
+++ b/arm9/source/patches/platform/acekard-common/IoRpgSdHelperPatchCode.s
@@ -63,9 +63,6 @@ iorpg_sdWaitForState_read_wait_data_ready:
     bcc iorpg_sdWaitForState_read_wait_data_ready // if not, loop
 
     ldr r7, [r5]
-    ldr r6, =0xFC2 // card ID
-    cmp r7, r6
-    beq iorpg_sdWaitForState_read_loop
 
 .global iorpg_sdWaitForState_shift
 iorpg_sdWaitForState_shift:


### PR DESCRIPTION
- Technically, DLDI uses this instead of SdWaitForState to wait for CMD17/CMD18 to finish loading the first sector.
- This adds support for the Galaxy Eagle line of flashcarts under the AK2 platform, which doesn't support using SdWaitForState that way.